### PR TITLE
Optimize lookup functions without standard library calls

### DIFF
--- a/ordinal_suffix.cpp
+++ b/ordinal_suffix.cpp
@@ -2,45 +2,15 @@
 
 const char *ft_ordinal_suffix(int number)
 {
-    if (number == 1)
-		return ("first");
-    else if (number == 2)
-		return ("second");
-    else if (number == 3)
-		return ("third");
-    else if (number == 4)
-		return ("fourth");
-    else if (number == 5)
-		return ("fifth");
-    else if (number == 6)
-		return ("sixth");
-    else if (number == 7)
-		return ("seventh");
-    else if (number == 8)
-		return ("eighth");
-    else if (number == 9)
-		return ("ninth");
-    else if (number == 10)
-		return ("tenth");
-    else if (number == 11)
-		return ("eleventh");
-    else if (number == 12)
-		return ("twelfth");
-    else if (number == 13)
-		return ("thirteenth");
-    else if (number == 14)
-		return ("fourteenth");
-    else if (number == 15)
-		return ("fifteenth");
-    else if (number == 16)
-		return ("sixteenth");
-    else if (number == 17)
-		return ("seventeenth");
-    else if (number == 18)
-		return ("eighteenth");
-    else if (number == 19)
-		return ("nineteenth");
-    else if (number == 20)
-		return ("twentieth");
+    static const char *suffix_table[20] = {
+        "first", "second", "third", "fourth", "fifth",
+        "sixth", "seventh", "eighth", "ninth", "tenth",
+        "eleventh", "twelfth", "thirteenth", "fourteenth",
+        "fifteenth", "sixteenth", "seventeenth", "eighteenth",
+        "nineteenth", "twentieth"
+    };
+
+    if (number >= 1 && number <= 20)
+        return (suffix_table[number - 1]);
     return ("nth");
 }

--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -83,11 +83,18 @@ static int ft_initiative_check(t_char * info, char **content, int i)
 
 static int ft_initiative_check_content(t_char * info, char **content)
 {
-    int index = 0;
+    int     index = 0;
+    size_t  name_len = 0;
 
+    while (info->name[name_len])
+        name_len++;
     while (content[index])
     {
-        if (ft_strncmp(content[index], info->name, ft_strlen(info->name)) == 0)
+        size_t j = 0;
+        while (j < name_len && content[index][j] &&
+               content[index][j] == info->name[j])
+            j++;
+        if (j == name_len)
             return (1);
         index++;
     }


### PR DESCRIPTION
## Summary
- use a lookup table for `ft_ordinal_suffix`
- avoid repeated string operations in initiative file lookup

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685f033ea648833184f62a1e92b365ef