### PR TITLE
Enable Windows and Linux support for cleaning commands

### DIFF
--- a/fclean.cpp
+++ b/fclean.cpp
@@ -1,9 +1,13 @@
 #include "dnd_tools.hpp"
 #include "libft/Printf/printf.hpp"
 #include "libft/CPP_class/nullptr.hpp"
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/wait.h>
+#if !defined(_WIN32)
+# include <sys/types.h>
+# include <unistd.h>
+# include <sys/wait.h>
+#else
+# include <filesystem>
+#endif
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
@@ -12,7 +16,8 @@
 
 void ft_fclean(void)
 {
-    int         status; 
+#if !defined(_WIN32)
+    int         status;
     const char  *command[4];
     pid_t       pid;
 
@@ -44,10 +49,25 @@ void ft_fclean(void)
                 pf_printf_fd(2, "140-Error: Command failed with exit status %d\n", exit_status);
         }
     }
+#else
+    if (g_dnd_test == false && ft_readline_confirm("type yes to confirm or no to abort: "))
+        return ;
+    std::error_code ec;
+    for (const auto &entry : std::filesystem::directory_iterator("./data", ec))
+    {
+        std::filesystem::remove_all(entry, ec);
+        if (ec)
+        {
+            pf_printf_fd(2, "138-Error: remove failed: %s\n", ec.message().c_str());
+            ec.clear();
+        }
+    }
+#endif
 }
 
 void ft_clean(void)
 {
+#if !defined(_WIN32)
     int         status;
     const char  *command[4];
     pid_t       pid;
@@ -55,7 +75,7 @@ void ft_clean(void)
     command[0] = "/bin/sh";
     command[1] = "-c";
     command[2] = "find ./data -mindepth 1 -maxdepth 1 \\( ! -name 'data--*' !" \
-				  "-name 'pc--*' \\) -exec rm -rf {} +";
+                                  "-name 'pc--*' \\) -exec rm -rf {} +";
     command[3] = ft_nullptr;
     if (g_dnd_test == 0 && ft_readline_confirm("type yes to confirm or no to abort: "))
         return ;
@@ -81,6 +101,23 @@ void ft_clean(void)
                 pf_printf_fd(2, "143-Error: Command failed with exit status %d\n", exit_status);
         }
     }
+#else
+    if (g_dnd_test == 0 && ft_readline_confirm("type yes to confirm or no to abort: "))
+        return ;
+    std::error_code ec;
+    for (const auto &entry : std::filesystem::directory_iterator("./data", ec))
+    {
+        std::string name = entry.path().filename().string();
+        if (name.rfind("data--", 0) == 0 || name.rfind("pc--", 0) == 0)
+            continue;
+        std::filesystem::remove_all(entry, ec);
+        if (ec)
+        {
+            pf_printf_fd(2, "143-Error: remove failed: %s\n", ec.message().c_str());
+            ec.clear();
+        }
+    }
+#endif
     return ;
 }
 


### PR DESCRIPTION
## Summary
- add platform checks in `fclean.cpp`
- use `std::filesystem` on Windows

## Testing
- `make objs/fclean.o` *(fails: libft missing)*

------
https://chatgpt.com/codex/tasks/task_e_68614c592d1c8331a3b9df6a9ae3ba5c