### PR TITLE
Implement growth stack buff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ SRC         = name.cpp \
               npc_change_stats_03.cpp \
               npc_change_stats_04.cpp \
               npc_update_buff_01.cpp \
+              growth_stack.cpp \
               utils01.cpp \
               utils02.cpp \
               debug.cpp \

--- a/attack.cpp
+++ b/attack.cpp
@@ -62,7 +62,7 @@ void ft_weapon_attack(t_char *info, t_equipment_id *weapon, int offhand)
     ft_check_dice_amount_and_faces(weapon, &d_info, offhand, info);
 	if (is_hit)
 	{
-    	ft_calculate_damage(weapon, &d_info, is_crit);
+    	ft_calculate_damage(info, weapon, &d_info, is_crit);
         ft_prompt_on_attack_success(info, is_crit);
 	}
 	t_attack_info attack_info = { .is_hit = is_hit, .is_crit = is_crit, .offhand = offhand };

--- a/attack_utils.cpp
+++ b/attack_utils.cpp
@@ -44,7 +44,7 @@ void ft_check_dice_amount_and_faces(t_equipment_id *weapon, t_damage_info *d_inf
     return ;
 }
 
-void ft_calculate_damage(t_equipment_id *weapon, t_damage_info *d_info, bool is_crit)
+void ft_calculate_damage(t_char *info, t_equipment_id *weapon, t_damage_info *d_info, bool is_crit)
 {
     int multiplier;
 
@@ -54,6 +54,14 @@ void ft_calculate_damage(t_equipment_id *weapon, t_damage_info *d_info, bool is_
         multiplier = 1;
     d_info->damage = ft_dice_roll(d_info->dice_amount * multiplier, d_info->dice_faces)
                      + d_info->stat_mod;
+    int reduction = info->bufs.growth.stacks;
+    if (reduction > 0)
+    {
+        d_info->damage -= reduction;
+        if (d_info->damage < 0)
+            d_info->damage = 0;
+        pf_printf("growth reduces damage by %d\n", reduction);
+    }
     pf_printf("deals %d %s damage\n", d_info->damage, weapon->attack.damage_type);
     return ;
 }

--- a/character.hpp
+++ b/character.hpp
@@ -166,6 +166,11 @@ typedef struct	s_buff_rejuvenation
 	int	healing_dice_faces;
 	int	healing_extra;
 }	t_buff_rejuvenation;
+typedef struct  s_buff_growth
+{
+	int     stacks;
+}       t_buff_growth;
+
 
 typedef struct	s_bufs
 {
@@ -180,6 +185,7 @@ typedef struct	s_bufs
 	t_buff_earth_pounce			earth_pounce;
 	t_buff_frost_breath			frost_breath;
     t_buff_shadow_illusion           shadow_illusion;
+        t_buff_growth				growth;
 	t_buff_rejuvenation			rejuvenation;
 }	t_bufs;
 

--- a/check_data.cpp
+++ b/check_data.cpp
@@ -186,6 +186,8 @@ static int check_buffs(t_char * info)
 			"rejuvenation dice faces");
 	error += check_range(info->bufs.rejuvenation.healing_extra, 0, 20, info->name,
 			"rejuvenation healing extra");
+        error += check_range(info->bufs.growth.stacks, 0, 10, info->name,
+                        "growth stacks");
 	error += check_range(info->spells.magic_drain.damage_flat, 0, 50, info->name,
 			"magic drain flat damage");
 	error += check_range(info->spells.magic_drain.damage_dice_amount, 0, 50, info->name,

--- a/deal_damage.cpp
+++ b/deal_damage.cpp
@@ -84,6 +84,12 @@ void ft_deal_damage(t_char * info, const char *input, const char *d_type,
             pf_printf("%s is immune to %s damage.\n", info->name, d_type);
             damage = 0;
         }
+        if (info->bufs.growth.stacks > 0) {
+            damage -= info->bufs.growth.stacks;
+            if (damage < 0)
+                damage = 0;
+            pf_printf("growth reduces damage by %d.\n", info->bufs.growth.stacks);
+        }
         temp = info->stats.health;
         info->stats.health = info->stats.health - damage;
         if (info->stats.health < 0)

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -193,7 +193,7 @@ void		ft_prompt_on_attack_success(t_char * character, bool critical_strike);
 int			ft_weapon_find_stat(t_char * info, t_equipment_id *weapon);
 void 		ft_check_dice_amount_and_faces(t_equipment_id *weapon, t_damage_info *d_info,
 				int offhand, t_char * info);
-void 		ft_calculate_damage(t_equipment_id *weapon, t_damage_info *d_info, bool is_crit);
+void            ft_calculate_damage(t_char *info, t_equipment_id *weapon, t_damage_info *d_info, bool is_crit);
 
 // Attack effects
 void 		ft_strength_drain(t_char *info, t_equipment_id *weapon,
@@ -329,6 +329,7 @@ void		ft_update_arcane_pounce(t_char * info);
 void		ft_update_frost_breath(t_char * info);
 void            ft_update_shadow_illusion(t_char * info);
 void		ft_update_buff_rejuvenation(t_char *info);
+void            ft_growth_stack(t_char * info, const char **input, int argc);
 
 // Feats
 void		ft_crackback(t_char * info, int number);

--- a/growth_stack.cpp
+++ b/growth_stack.cpp
@@ -1,0 +1,39 @@
+#include "dnd_tools.hpp"
+#include "libft/Printf/printf.hpp"
+
+void    ft_growth_stack(t_char *info, const char **input, int argc)
+{
+	int amount = 1;
+	if (argc == 5)
+	{
+		if (ft_check_value(input[4]))
+		{
+			pf_printf_fd(2, "Growth stack expects a number between 1 and 10\n");
+			return ;
+		}
+		amount = ft_atoi(input[4]);
+	}
+	if (amount < 1 || amount > 10)
+	{
+		pf_printf_fd(2, "Growth stack expects a number between 1 and 10\n");
+		return ;
+	}
+	if (ft_strcmp_dnd(input[1], "add") == 0)
+	{
+		info->bufs.growth.stacks += amount;
+		if (info->bufs.growth.stacks > 10)
+			info->bufs.growth.stacks = 10;
+		pf_printf("%s gains %d growth stack(s) (total %d)\n", info->name, amount,
+			      info->bufs.growth.stacks);
+	}
+	else if (ft_strcmp_dnd(input[1], "remove") == 0)
+	{
+		info->bufs.growth.stacks -= amount;
+		if (info->bufs.growth.stacks < 0)
+			info->bufs.growth.stacks = 0;
+		pf_printf("%s loses %d growth stack(s) (total %d)\n", info->name, amount,
+			      info->bufs.growth.stacks);
+	}
+	else
+		pf_printf_fd(2, "Growth stack invalid command\n");
+}

--- a/identification.hpp
+++ b/identification.hpp
@@ -112,7 +112,8 @@ typedef enum e_equipment_slot
     X(HUNTERS_MARK, 1, "hunters mark") \
     X(BLESS, 2, "bless") \
     X(CHAOS_ARMOR, 3, "chaos armor") \
-    X(MAGIC_DRAIN, 4, "magic drain")
+    X(MAGIC_DRAIN, 4, "magic drain") \
+    X(GROWTH, 5, "growth")
 
 #define X(name, id, str)  enum { name##_ID = id };
 ABILITY_LIST

--- a/initialize.hpp
+++ b/initialize.hpp
@@ -268,6 +268,11 @@ static const	t_buff_rejuvenation INITIALIZE_BUFF_REJUVENATION =
 	.healing_dice_faces = 0,
 	.healing_extra = 0,
 };
+static const    t_buff_growth INITIALIZE_BUFF_GROWTH =
+{
+        .stacks = 0,
+};
+
 
 static const	t_bufs INITIALIZE_BUFFS =
 {
@@ -283,6 +288,7 @@ static const	t_bufs INITIALIZE_BUFFS =
 	.frost_breath = INITIALIZE_BUFF_FROST_BREATH,
     .shadow_illusion = INITIALIZE_BUFF_SHADOW_ILLUSION,
 	.rejuvenation = INITIALIZE_BUFF_REJUVENATION,
+        .growth = INITIALIZE_BUFF_GROWTH,
 };
 
 static const	t_debuff_hunters_mark INITIALIZE_HUNTERS_MARK =

--- a/initialize_key_value_pairs.cpp
+++ b/initialize_key_value_pairs.cpp
@@ -207,6 +207,7 @@ int initialize_stat_key_value_pairs(t_char *info)
 	tree_node_insert(node, BUFF_REJUVENATION_DICE_FACES_KEY,
 			&info->bufs.rejuvenation.healing_dice_amount, -1);
 	tree_node_insert(node, BUFF_REJUVENATION_EXTRA_KEY, &info->bufs.rejuvenation.healing_extra, -1);
+	tree_node_insert(node, BUFF_GROWTH_STACKS_KEY, &info->bufs.growth.stacks, -1);
 	if (tree_node_get_error(node))
         return (1);
     return (0);

--- a/key_list.hpp
+++ b/key_list.hpp
@@ -193,6 +193,8 @@ constexpr bool is_valid_key(const char* str)
 	X(BUFF_REJUVENATION_DICE_FACES_KEY, "BUFF_REJUVENATION_DICE_FACES=") \
 	X(BUFF_REJUVENATION_EXTRA_KEY, "BUFF_REJUVENATION_EXTRA=")
 
+	X(BUFF_GROWTH_STACKS_KEY, "BUFF_GROWTH_STACKS=") 
+
 #define X(name, value) \
     static_assert(ends_with(#name, "_KEY"), "Macro name must end with _KEY"); \
     static_assert(is_valid_key(value), "Invalid key: " value); \

--- a/npc_stats.cpp
+++ b/npc_stats.cpp
@@ -57,11 +57,17 @@ void ft_npc_change_stats(t_char * info, const int argument_count, const char **a
     }
 	else if (argument_count == 2)
         ft_npc_sstuff(info, argument_vector);
-	else if (argument_count == 3)
+        else if (argument_count == 3)
         ft_npc_set_stat(info, argument_vector);
-	else if (argument_count == 4)
+        else if ((argument_count == 4 || argument_count == 5) &&
+            ((ft_strcmp_dnd(argument_vector[1], "add") == 0) ||
+             (ft_strcmp_dnd(argument_vector[1], "remove") == 0)) &&
+            ft_strcmp_dnd(argument_vector[2], "stack") == 0 &&
+            ft_strcmp_dnd(argument_vector[3], "growth") == 0)
+        ft_growth_stack(info, argument_vector, argument_count);
+        else if (argument_count == 4)
         ft_change_stats_04(info, argument_vector);
-	else
+        else
         pf_printf_fd(2, "146-Error Too many arguments given\n");
 	if (info->flags.alreaddy_saved == 1)
 		return ;

--- a/save_data.cpp
+++ b/save_data.cpp
@@ -205,6 +205,7 @@ static void ft_npc_write_file_2(t_char * info, t_resistance *resistance, ft_file
             info->bufs.shadow_illusion.active);
     file.printf("%s%i\n", SHADOW_ILLUSION_DURATION_KEY,
             info->bufs.shadow_illusion.duration);
+    file.printf("%s%i\n", BUFF_GROWTH_STACKS_KEY, info->bufs.growth.stacks);
 	file.printf("%s%s\n", METEOR_STRIKE_TARGET_KEY,
 			info->bufs.meteor_strike.target_id);
 	if (info->bufs.frost_breath.target_id)


### PR DESCRIPTION
## Summary
- add `growth` ability with stack-based buff
- modify damage calculations to apply growth stack reduction
- register growth buff in initialization and save/load logic
- add CLI command for managing growth stacks
- fix indentation for new growth stack code

## Testing
- `make` *(fails: No targets specified and no makefile found)*


------
https://chatgpt.com/codex/tasks/task_e_68682d7cad3483319f1727147df9c369