### PR TITLE
Fix null pointer free in player.cpp

### DIFF
--- a/player.cpp
+++ b/player.cpp
@@ -81,7 +81,10 @@ void	ft_player(const char **input)
 	}
 	else
 		pf_printf("243-Error: Invalid input for player\n");
-	cma_free(player->name);
-	cma_free(player);
+    if (player)
+    {
+        cma_free(player->name);
+        cma_free(player);
+    }
 	return ;
 }


### PR DESCRIPTION
## Summary
- guard against freeing NULL player struct

## Testing
- `make` *(fails: No targets specified and no makefile found for libft)*

------
https://chatgpt.com/codex/tasks/task_e_686f939e351c8331b30cdff3d6e08469