### PR TITLE
Fix bug in ft_free_memory_cmt

### DIFF
--- a/free_memory.cpp
+++ b/free_memory.cpp
@@ -50,8 +50,8 @@ void	ft_free_memory_cmt(t_target_data *target_data, int amount)
         }
 		if (target_data->target_copy[index])
 		{
-			ft_free_info(target_data->target_copy[index]);
-			target_data->target[index] = ft_nullptr;
+            ft_free_info(target_data->target_copy[index]);
+            target_data->target_copy[index] = ft_nullptr;
 		}
         if (target_data->Pchar_name[index])
         {


### PR DESCRIPTION
## Summary
- fix a pointer bug when cleaning up copied targets

## Testing
- `make` *(fails: No targets specified and no makefile found in libft)*
- `g++ -c free_memory.cpp -std=c++17 -Wall -Werror -Wextra` *(fails: libft submodule missing)*

------
https://chatgpt.com/codex/tasks/task_e_68710cab6f40833196d4b325b70405da