### PR TITLE
Switch submodule to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "libft"]
 	path = libft
-	url = git@github.com:Adyem/Libft.git
+       url = https://github.com/Adyem/Libft.git
 	branch = master


### PR DESCRIPTION
## Summary
- update the libft submodule URL to use HTTPS so it can be fetched without SSH

## Testing
- `git submodule update --init`

------
https://chatgpt.com/codex/tasks/task_e_68710f745edc8331b4597bb9ae4f9e11