### PR TITLE
Fix double-char free bug

### DIFF
--- a/roll_utilities.cpp
+++ b/roll_utilities.cpp
@@ -57,11 +57,11 @@ void	ft_free_parse(char **to_parse)
 
 	if (to_parse)
 	{
-		while (to_parse[index])
-		{
-			cma_free(to_parse[1]);
-			index++;
-		}
+               while (to_parse[index])
+               {
+                        cma_free(to_parse[index]);
+                        index++;
+               }
 		cma_free(to_parse);
 	}
 	return ;


### PR DESCRIPTION
## Summary
- fix incorrect index usage when freeing parsed input

## Testing
- `make clean`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68711a66d9a08331a35e2dd107eafd10