### PR TITLE
Add success/fail readline check

### DIFF
--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -16,6 +16,10 @@ static_assert(sizeof(int) == 4, "Expected int to be 4 bytes");
 # define MAX_PLAYERS 8
 # define CRIT_SUCCES 999
 # define CRIT_FAIL -999
+# define RL_CRIT_SUCCES 1
+# define RL_SUCCES 2
+# define RL_FAIL 3
+# define RL_CRIT_FAIL 4
 
 extern bool g_dnd_test;
 
@@ -408,6 +412,7 @@ int			ft_check_player_character(const char *name);
 
 // Readline checks
 int			ft_readline_confirm(const char *mesage);
+int                     ft_readline_check_succes_or_fail(const char *message);
 int			ft_readline_spell_level(const char *message, t_char * character,
 				int *invalid_input_amount);
 

--- a/fel_poison_weapon_effects.cpp
+++ b/fel_poison_weapon_effects.cpp
@@ -10,11 +10,15 @@ void ft_fel_poison_attack_effects(t_char *info, t_equipment_id *weapon, t_equipm
 	(void)effect;
 	if (!attack_info->is_hit)
 		return ;
-    const char *message = "the target needs to succeed on a DC15 constitution " \
-					 "save or become poisoned";
+    const char *message =
+        "the target needs to succeed on a DC15 constitution save or become poisoned.\n"
+        "Enter \"crit succes\", \"succes\", \"fail\" or \"crit fail\": ";
     if (!message)
         return ;
-    if (ft_readline_confirm(message))
+    int result_check = ft_readline_check_succes_or_fail(message);
+    if (result_check == RL_CRIT_SUCCES || result_check == RL_SUCCES)
+        return ;
+    if (result_check == RL_FAIL || result_check == RL_CRIT_FAIL)
     {
         int result = ft_dice_roll(weapon->action_01.effect_dice_amount,
                 weapon->action_01.effect_dice_faces) + weapon->action_01.bonus_mod;

--- a/readline_check.cpp
+++ b/readline_check.cpp
@@ -28,8 +28,45 @@ int	ft_readline_confirm(const char *message)
 			return (1);
 		}
 	}
-	pf_printf_fd(2, "116-Error: read line memory allocation failed\n");
-	return (-1);
+        pf_printf_fd(2, "116-Error: read line memory allocation failed\n");
+        return (-1);
+}
+
+int     ft_readline_check_succes_or_fail(const char *message)
+{
+        char    *input;
+
+        if (g_dnd_test == true)
+                return (ft_dice_roll(1, 4));
+        while ((input = rl_readline(message)) != ft_nullptr)
+        {
+                if ((ft_strcmp_dnd(input, "crit succes") == 0)
+                        || (ft_strcmp_dnd(input, "crit success") == 0))
+                {
+                        cma_free(input);
+                        return (RL_CRIT_SUCCES);
+                }
+                else if ((ft_strcmp_dnd(input, "succes") == 0)
+                        || (ft_strcmp_dnd(input, "success") == 0))
+                {
+                        cma_free(input);
+                        return (RL_SUCCES);
+                }
+                else if ((ft_strcmp_dnd(input, "crit fail") == 0)
+                        || (ft_strcmp_dnd(input, "critical fail") == 0))
+                {
+                        cma_free(input);
+                        return (RL_CRIT_FAIL);
+                }
+                else if ((ft_strcmp_dnd(input, "fail") == 0)
+                        || (ft_strcmp_dnd(input, "failure") == 0))
+                {
+                        cma_free(input);
+                        return (RL_FAIL);
+                }
+        }
+        pf_printf_fd(2, "116-Error: read line memory allocation failed\n");
+        return (-1);
 }
 
 static int ft_check_spell_slots(int spell_level, t_char * character)


### PR DESCRIPTION
## Summary
- expand dnd_tools constants with new success/fail reply macros
- add `ft_readline_check_succes_or_fail` for detailed user input
- update Fel Poison weapon effect to use the new check

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6880f3045dc0833186ab2b8f072b5953