### PR TITLE
Handle shadow illusion death cleanup

### DIFF
--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -461,7 +461,7 @@ void		ft_initiative_print(void);
 t_pc		*ft_initiative_players_am(char **content);
  
 // Initiative update file
-void		ft_initiative_remove(t_char * info);
+int             ft_initiative_remove(t_char * info);
 void		ft_initiative_add(t_char * info);
 
 // Command roll

--- a/print_hp_status.cpp
+++ b/print_hp_status.cpp
@@ -1,5 +1,7 @@
 #include "libft/Printf/printf.hpp"
 #include "dnd_tools.hpp"
+#include "libft/Libft/libft.hpp"
+#include <unistd.h>
 
 void ft_print_character_status(t_char * info, int number, int temp)
 {
@@ -50,7 +52,17 @@ void ft_print_character_status(t_char * info, int number, int temp)
             else
                 pf_printf("%s encountered a setback with %d excess damage\n", info->name,
 						(-number - temp));
-            ft_initiative_remove(info);
+            int had_turn = ft_initiative_remove(info);
+            if (ft_strncmp(info->name, "shadow_illusion_", 15) == 0)
+            {
+                if (info->save_file)
+                {
+                    if (unlink(info->save_file) == 0 && DEBUG == 1)
+                        pf_printf("Deleted save file for %s\n", info->name);
+                }
+                if (had_turn)
+                    ft_turn_next(info->struct_name);
+            }
         }
         else if (number < 0)
             pf_printf("%s has received %d damage and now has %d health remaining\n", info->name,

--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -9,11 +9,12 @@
 #include <cerrno>
 #include <cstring>
 
-void ft_initiative_remove(t_char * info)
+int ft_initiative_remove(t_char * info)
 {
     char    *temp;
     char    **content;
     int     turn_marker;
+    int     removed_turn;
 
     if (DEBUG == 1)
         pf_printf("removing initiative %s\n", info->name);
@@ -21,20 +22,21 @@ void ft_initiative_remove(t_char * info)
     {
         if (DEBUG == 1)
             pf_printf("File does not exist: data/data--initiative\n");
-        return ;
+        return (0);
     }
     content = ft_open_and_read_file("data/data--initiative");
     if (!content)
-        return ;
+        return (0);
     ft_file initiative_file("data/data--initiative", O_WRONLY | O_TRUNC);
     if (initiative_file.get_error())
     {
         pf_printf("Error opening file: %s\n", initiative_file.get_error_str());
         cma_free_double(content);
-        return ;
+        return (0);
     }
     int index = 0;
     turn_marker = 0;
+    removed_turn = 0;
     while (content[index])
     {
         if (ft_strncmp(content[index], "--turn--", 8) == 0)
@@ -53,6 +55,8 @@ void ft_initiative_remove(t_char * info)
                 pf_printf("found one %s and %c\n", content[index], content[index][ft_strlen(info->name)]);
             index++;
             if (turn_marker)
+                removed_turn = 1;
+            if (turn_marker)
                 pf_printf_fd(initiative_file, "--turn--");
             continue ;
         }
@@ -61,7 +65,7 @@ void ft_initiative_remove(t_char * info)
         index++;
     }
     cma_free_double(content);
-    return ;
+    return (removed_turn);
 }
 
 static int ft_initiative_check(t_char * info, char **content, int i)


### PR DESCRIPTION
## Summary
- remove initiative entry and clean up turn tracking on death
- delete shadow illusion save file when killed
- automatically pass turn if the illusion had the current turn

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688bb2eda58483318cd84a7f2dd2c0cc