### PR TITLE
Fix Xavius shadow illusion duration

### DIFF
--- a/xavius.cpp
+++ b/xavius.cpp
@@ -66,6 +66,8 @@ static void     ft_spawn_shadow_clone(t_char *info)
             ft_shadow_illusion(2, input, info->struct_name, 0);
             cma_free(path);
             cma_free(const_cast<char *>(input[0]));
+            info->bufs.shadow_illusion.active = 1;
+            info->bufs.shadow_illusion.duration = 1;
             print_shadow_illusion(info);
             return ;
         }


### PR DESCRIPTION
## Summary
- Ensure Xavius activates the shadow illusion buff and sets its duration when spawning a clone, allowing the ability text to report a non-zero duration

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6891063a56288331918c28f4db2b33a4