### PR TITLE
Add encounter damage subcommands

### DIFF
--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -228,7 +228,7 @@ void		ft_update_buff_status(t_char * info, int current_dur, int duration,
 				const char *buff_name);
 
 // Init Encounter
-void		ft_encounter(const char *encounter_name, t_name *name);
+void            ft_encounter(int argument_count, const char **argument_vector, t_name *name);
 
 // Damage buffs
 int			ft_check_buff_damage(t_char * info);

--- a/encounter.cpp
+++ b/encounter.cpp
@@ -1,13 +1,56 @@
 #include "dnd_tools.hpp"
+#include "libft/CPP_class/nullptr.hpp"
+#include "libft/Printf/printf.hpp"
 
-void	ft_encounter(const char *encounter_name, t_name *name)
+void    ft_encounter(int argument_count, const char **argument_vector, t_name *name)
 {
-	if (ft_strcmp_dnd(encounter_name, "xavius") == 0)
-	{
-		ft_excecute_test("shield_spell_a", "init", name);
-		ft_excecute_test("demonic_portal_a", "init", name);
-		ft_excecute_test("xavius", "init", name);
-		ft_excecute_test("malfurion", "init", name);
-	}
-	return ;
+    if (argument_count >= 1 && ft_strcmp_dnd(argument_vector[0], "xavius") == 0)
+    {
+        if (argument_count == 1)
+        {
+            ft_excecute_test("shield_spell_a", "init", name);
+            ft_excecute_test("demonic_portal_a", "init", name);
+            ft_excecute_test("xavius", "init", name);
+            ft_excecute_test("malfurion", "init", name);
+        }
+        else if (argument_count >= 3 && ft_strcmp_dnd(argument_vector[1], "damage") == 0)
+        {
+            if (ft_strcmp_dnd(argument_vector[2], "portal") == 0)
+            {
+                const char      *input[] = {"demonic_portal_a", ft_nullptr};
+                t_char          *info = ft_demonic_portal_a(1, input, name, 1);
+
+                if (info != ft_nullptr)
+                {
+                    ft_deal_damage(info, "1", "force", 0, 1);
+                    ft_file file(info->save_file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+                    if (file.get_error())
+                        pf_printf_fd(2, "123-Error opening file %s: %s\n", info->save_file, file.get_error_str());
+                    else
+                        ft_npc_write_file(info, &info->stats, &info->d_resistance, file);
+                    ft_free_info(info);
+                }
+            }
+            else if (argument_count >= 4 &&
+                    ft_strcmp_dnd(argument_vector[2], "shield") == 0 &&
+                    ft_strcmp_dnd(argument_vector[3], "spell") == 0)
+            {
+                const char      *input[] = {"shield_spell_a", ft_nullptr};
+                t_char          *info = ft_shield_spell_a(1, input, name, 1);
+
+                if (info != ft_nullptr)
+                {
+                    ft_deal_damage(info, "1", "force", 0, 1);
+                    ft_file file(info->save_file, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
+                    if (file.get_error())
+                        pf_printf_fd(2, "123-Error opening file %s: %s\n", info->save_file, file.get_error_str());
+                    else
+                        ft_npc_write_file(info, &info->stats, &info->d_resistance, file);
+                    ft_free_info(info);
+                }
+            }
+        }
+    }
+    return ;
 }
+

--- a/help.cpp
+++ b/help.cpp
@@ -14,5 +14,6 @@ void ft_print_help(void)
     pf_printf("  test                Run test sequence\n");
     pf_printf("  add player <name>   Add a new player\n");
     pf_printf("  encounter <name>    Start encounter from file\n");
+    pf_printf("  encounter xavius damage <portal|shield spell>   Deal 1 damage\n");
     return ;
 }

--- a/read_line.cpp
+++ b/read_line.cpp
@@ -53,10 +53,10 @@ static int ft_handle_builtins(char **input, int i, t_name *name, char *input_str
         ft_test(name);
 	else if (i == 1 && ft_strcmp_dnd(input[0], "help") == 0)
         ft_print_help();
-	else if (i == 3 && ft_strcmp_dnd(input[1], "player") == 0)
+        else if (i == 3 && ft_strcmp_dnd(input[1], "player") == 0)
         ft_player(const_cast<const char **>(input));
-	else if (i == 2 && ft_strcmp_dnd(input[0], "encounter") == 0)
-		ft_encounter(input[1], name);
+        else if (i >= 2 && ft_strcmp_dnd(input[0], "encounter") == 0)
+                ft_encounter(i - 1, const_cast<const char **>(input + 1), name);
 	else
 		return (0);
 	return (1);

--- a/test.cpp
+++ b/test.cpp
@@ -27,7 +27,9 @@ void	ft_test(t_name *name)
 	ft_excecute_test("snow_goblin_01", "ranged_attack", name);
 	ft_excecute_test("night_elven_guard_01", "init", name);
 	ft_excecute_test("night_elven_guard_01", "ranged_attack", name);
-	ft_excecute_test("encounter", "xavius", name);
-	g_dnd_test = false;
-	return ;
+        ft_excecute_test("encounter", "xavius", name);
+        ft_excecute_test("encounter", "xavius", "damage", "portal", name);
+        ft_excecute_test("encounter", "xavius", "damage", "shield", "spell", name);
+        g_dnd_test = false;
+        return ;
 }

--- a/test_excecute.cpp
+++ b/test_excecute.cpp
@@ -35,10 +35,10 @@ static int ft_handle_builtins(const char **input, int index, t_name *name)
         ft_test(name);
 	else if (index == 1 && ft_strcmp_dnd(input[0], "help") == 0)
         ft_print_help();
-	else if (index == 3 && ft_strcmp_dnd(input[1], "player") == 0)
+        else if (index == 3 && ft_strcmp_dnd(input[1], "player") == 0)
         ft_player(input);
-	else if (index == 2 && ft_strcmp_dnd(input[0], "encounter") == 0)
-		ft_encounter(input[1], name);
+        else if (index >= 2 && ft_strcmp_dnd(input[0], "encounter") == 0)
+                ft_encounter(index - 1, input + 1, name);
 	else
 		return (0);
 	return (1);


### PR DESCRIPTION
## Summary
- allow `encounter xavius damage portal` to apply 1 damage to the encounter's demonic portal
- add `encounter xavius damage shield spell` to remove 1 HP from the protective shield spell
- document and test the new encounter damage subcommands

## Testing
- `make -j8`
- `script -q -c "printf 'encounter xavius damage portal\nencounter xavius damage shield spell\nexit\n' | ./dnd_tools" /tmp/run.log`


------
https://chatgpt.com/codex/tasks/task_e_68923c398888833193f62e5dc6ed0ac3