### PR TITLE
Update spell utils to report correct spell names

### DIFF
--- a/cast_bless.cpp
+++ b/cast_bless.cpp
@@ -34,7 +34,8 @@ void ft_cast_bless(t_char *info, const char **input)
 		pf_printf_fd(2, "%s hasn't learned the spell bless\n", info->name);
 		return ;
 	}
-	int cast_at_level = ft_prompt_spell_level(info, info->spells.bless.base_level);
+        int cast_at_level = ft_prompt_spell_level(info, info->spells.bless.base_level,
+                                BLESS_NAME);
 	if (cast_at_level == -1)
 		return ;
 	t_buff buff = MAKE_BUFF_BLESS(info->spells.bless, cast_at_level, input[3]);

--- a/cast_cure_wounds.cpp
+++ b/cast_cure_wounds.cpp
@@ -17,7 +17,7 @@ void ft_cast_cure_wounds(t_char * character)
     if (!ft_check_cure_wounds_learned(character))
         return ;
     int base_level = character->spells.cure_wounds.base_level;
-    int cast_at_level = ft_prompt_spell_level(character, base_level);
+    int cast_at_level = ft_prompt_spell_level(character, base_level, "Cure Wounds");
     if (cast_at_level == -1)
         return ;
     t_spell_cure_wounds *cure_wounds = &character->spells.cure_wounds;

--- a/cast_divine_smite.cpp
+++ b/cast_divine_smite.cpp
@@ -21,7 +21,7 @@ void ft_cast_divine_smite(t_char * character, bool critical_strike)
 	if (!ft_check_divine_smite_learned(character))
 		return ;
     int base_level = character->spells.divine_smite.base_level;
-	int cast_at_level = ft_prompt_spell_level(character, base_level);
+        int cast_at_level = ft_prompt_spell_level(character, base_level, "Divine Smite");
     if (cast_at_level == -1)
         return ;
     t_spell_divine_smite *divine_smite = &character->spells.divine_smite;

--- a/cast_hunters_mark.cpp
+++ b/cast_hunters_mark.cpp
@@ -38,7 +38,8 @@ void ft_cast_hunters_mark(t_char * info, const char **input)
 		pf_printf_fd(2, "%s hasn't learned the spell hunters mark\n", info->name);
 		return ;
 	}
-	int cast_at_level = ft_prompt_spell_level(info, info->spells.hunters_mark.base_level);
+        int cast_at_level = ft_prompt_spell_level(info, info->spells.hunters_mark.base_level,
+                                HUNTERS_MARK_NAME);
 	if (cast_at_level == -1)
 		return ;
 	t_buff buff = MAKE_BUFF_HUNTERS_MARK(info->spells.hunters_mark, cast_at_level, input[3]);

--- a/cast_lightning_bolt.cpp
+++ b/cast_lightning_bolt.cpp
@@ -18,7 +18,7 @@ void ft_cast_lightning_bolt(t_char * character)
     if (!ft_check_lightning_bolt_learned(character))
         return ;
     int base_level = character->spells.lightning_bolt.base_level;
-    int cast_at_level = ft_prompt_spell_level(character, base_level);
+    int cast_at_level = ft_prompt_spell_level(character, base_level, "Lightning Bolt");
     if (cast_at_level == -1)
         return ;
     t_spell_lightning_bolt *lightning_bolt = &character->spells.lightning_bolt;

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -249,7 +249,7 @@ void        ft_cast_lightning_bolt(t_char * character);
 void		ft_cast_rejuvenation(const char **input, t_char *info);
 
 // Spells utils
-int			ft_prompt_spell_level(t_char * character, int base_level);
+int			ft_prompt_spell_level(t_char * character, int base_level, const char *spell_name);
 int			ft_calculate_spell_damage(int total_dice, int dice_faces, int extra_damage);
 int			ft_calculate_spell_healing(int total_dice, int dice_faces, int extra_damage);
 void		ft_remove_spell_slot(t_spell_slots *spell_slots, int level_spell_used);

--- a/spell_utils.cpp
+++ b/spell_utils.cpp
@@ -5,7 +5,7 @@
 #include "libft/Printf/printf.hpp"
 #include <cassert>
 
-static int ft_auto_cast(t_char *character, int base_level)
+static int ft_auto_cast(t_char *character, int base_level, const char *spell_name)
 {
 	if (character->spell_slots.level_1.available > 0 && base_level >= 1)
         return (1);
@@ -23,10 +23,10 @@ static int ft_auto_cast(t_char *character, int base_level)
         return (7);
 	if (character->spell_slots.level_8.available > 0 && base_level >= 8)
         return (8);
-	if (character->spell_slots.level_9.available > 0 && base_level >= 9)
+    if (character->spell_slots.level_9.available > 0 && base_level >= 9)
         return (9);
-	pf_printf_fd(2, "Error: No available spell slots for %s to cast Divine Smite.\n",
-                character->name);
+    pf_printf_fd(2, "Error: No available spell slots for %s to cast %s.\n",
+            character->name, spell_name);
     return (-1);
 }
 
@@ -57,13 +57,13 @@ static ft_string ft_check_availeble_spell_slots(t_char *character, int base_leve
 	return (available_levels);
 }
 
-int ft_prompt_spell_level(t_char *character, int base_level)
+int ft_prompt_spell_level(t_char *character, int base_level, const char *spell_name)
 {
-	assert (base_level >= 0 && base_level <= 9);
+        assert (base_level >= 0 && base_level <= 9);
 
-	if (g_dnd_test)
-		return (ft_auto_cast(character, base_level));
-	ft_string available_slots = ft_check_availeble_spell_slots(character, base_level);
+        if (g_dnd_test)
+                return (ft_auto_cast(character, base_level, spell_name));
+        ft_string available_slots = ft_check_availeble_spell_slots(character, base_level);
     if (available_slots.get_error())
     {
         pf_printf_fd(2, "Error: Failed to retrieve available spell slots for %s.\n",
@@ -72,8 +72,8 @@ int ft_prompt_spell_level(t_char *character, int base_level)
     }
     if (available_slots.empty())
     {
-        pf_printf_fd(2, "Error: No available spell slots for %s to cast Divine Smite.\n",
-                character->name);
+        pf_printf_fd(2, "Error: No available spell slots for %s to cast %s.\n",
+                character->name, spell_name);
         return (-1);
     }
     ft_string message = "Select the level you want to cast the spell at: "


### PR DESCRIPTION
## Summary
- pass spell names into spell level prompt utility
- remove hard-coded "Divine Smite" from spell slot errors

## Testing
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68926fbd1dbc833195b22691f9c6dd0a