### PR TITLE
Add feat for STR/CON save advantage

### DIFF
--- a/character.hpp
+++ b/character.hpp
@@ -286,9 +286,15 @@ typedef struct s_crackback
 	int	active;
 }	t_crackback;
 
+typedef struct s_mighty_resilience
+{
+	int	active;
+}	t_mighty_resilience;
+
 typedef struct s_feats
 {
 	t_crackback	crackback;
+	t_mighty_resilience	mighty_resilience;
 }	t_feats;
 
 typedef struct s_equipment_action

--- a/check_buff_save.cpp
+++ b/check_buff_save.cpp
@@ -2,11 +2,14 @@
 
 int	ft_save_check_buff(t_char * info, int *roll, const char *ability_score)
 {
-	(void)ability_score;
 	int	return_value;
 
 	return_value = 0;
 	return_value += ft_check_bless(info);
+	if (info->feats.mighty_resilience.active &&
+	    (ft_strcmp_dnd(ability_score, "strength") == 0 ||
+	     ft_strcmp_dnd(ability_score, "constitution") == 0))
+	        info->flags.advantage++;
 	ft_reroll(info, roll);
 	return (return_value);
 }

--- a/initialize.hpp
+++ b/initialize.hpp
@@ -348,14 +348,20 @@ static const	t_flags INITIALIZE_FLAGS =
 	.dont_save = 0,
 };
 
-static const	t_crackback INITIALIZE_CRACKBACK =
+static const	 t_crackback INITIALIZE_CRACKBACK =
 {
 	.active = 0,
 };
 
-static const	t_feats INITIALIZE_FEATS =
+static const	 t_mighty_resilience INITIALIZE_MIGHTY_RESILIENCE =
+{
+	.active = 0,
+};
+
+static const	 t_feats INITIALIZE_FEATS =
 {
 	.crackback = INITIALIZE_CRACKBACK,
+	.mighty_resilience = INITIALIZE_MIGHTY_RESILIENCE,
 };
 
 static const t_spell_slot INITIALIZE_SPELL_SLOT =


### PR DESCRIPTION
## Summary
- define Mighty Resilience feat structure and integrate into character feats
- apply advantage on Strength and Constitution saves when Mighty Resilience is active
- initialize new feat defaults

## Testing
- `make -j4` *(fails: use of old-style cast in libft)*

------
https://chatgpt.com/codex/tasks/task_e_68ab54c35d588331b7a5401fd58c5e46