### PR TITLE
Add basic coordinate tracking for characters

### DIFF
--- a/ancient_predatory_beast.hpp
+++ b/ancient_predatory_beast.hpp
@@ -184,6 +184,7 @@ static const t_char ANCIENT_PREDATORY_BEAST_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = ANCIENT_PREDATORY_BEAST_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/chaos_crystal.hpp
+++ b/chaos_crystal.hpp
@@ -149,6 +149,7 @@ static const t_char CHAOS_CRYSTAL_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = CHAOS_CRYSTAL_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/chaos_goblin.hpp
+++ b/chaos_goblin.hpp
@@ -152,6 +152,7 @@ static const t_char CHAOS_GOBLIN_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = CHAOS_GOBLIN_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/character.hpp
+++ b/character.hpp
@@ -554,6 +554,13 @@ typedef struct s_hit_dice
     int dice_faces;
 } t_hit_dice;
 
+typedef struct s_position
+{
+    int x;
+    int y;
+    int z;
+} t_position;
+
 typedef struct    s_char
 {
     int                level;
@@ -586,6 +593,7 @@ typedef struct    s_char
     t_feats            feats;
     t_name            *struct_name;
     t_physical      physical;
+    t_position      position;
 }    t_char;
 
 typedef int        (*cast_buff_debuff)(t_char * , const char **, t_buff *);

--- a/check_data.cpp
+++ b/check_data.cpp
@@ -72,6 +72,15 @@ static int check_resistances(t_char * info)
     return (error);
 }
 
+static int check_position(t_char * info)
+{
+    int error = 0;
+    error += check_range(info->position.x, 0, MAX_COORDINATE, info->name, "position_x");
+    error += check_range(info->position.y, 0, MAX_COORDINATE, info->name, "position_y");
+    error += check_range(info->position.z, 0, MAX_COORDINATE, info->name, "position_z");
+    return (error);
+}
+
 static int check_concentration(t_char * info)
 {
     int error = 0;
@@ -339,6 +348,7 @@ int ft_npc_check_info(t_char * info)
 {
     int error = 0;
     error += check_stats(info);
+    error += check_position(info);
     error += check_spell_slots(info);
     error += check_other_buffs_debuffs(info);
     error += ft_check_equipment_slots(info);

--- a/demonic_portal_a.hpp
+++ b/demonic_portal_a.hpp
@@ -184,6 +184,7 @@ static const t_char DEMONIC_PORTAL_A_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = DEMONIC_PORTAL_A_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -14,6 +14,7 @@ static_assert(sizeof(int) == 4, "Expected int to be 4 bytes");
 
 # define MAX_ERROR_COUNT 5
 # define MAX_PLAYERS 8
+# define MAX_COORDINATE 10000
 # define CRIT_SUCCES 999
 # define CRIT_FAIL -999
 # define RL_CRIT_SUCCES 1

--- a/dorgar_stoneguard.hpp
+++ b/dorgar_stoneguard.hpp
@@ -149,6 +149,7 @@ static const    t_char DORGAR_STONEGUARD_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = DORGAR_STONEGUARD_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/dwarf_paladin.hpp
+++ b/dwarf_paladin.hpp
@@ -222,6 +222,7 @@ static const t_char DWARF_PALADIN_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = DWARF_PALADIN_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/felbeast.hpp
+++ b/felbeast.hpp
@@ -184,6 +184,7 @@ static const t_char FELBEAST_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = FELBEAST_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/felguard.hpp
+++ b/felguard.hpp
@@ -184,6 +184,7 @@ static const t_char FELGUARD_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = FELGUARD_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/frank.hpp
+++ b/frank.hpp
@@ -151,6 +151,7 @@ static const t_char FRANK_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = FRANK_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/ghost.hpp
+++ b/ghost.hpp
@@ -164,6 +164,7 @@ static const t_char GHOST_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = GHOST_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/goblin.hpp
+++ b/goblin.hpp
@@ -151,6 +151,7 @@ static const t_char GOBLIN_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = GOBLIN_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/goblin_warmaster.hpp
+++ b/goblin_warmaster.hpp
@@ -150,6 +150,7 @@ static const t_char GOBLIN_WARMASTER_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = GOBLIN_WARMASTER_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/grizz.hpp
+++ b/grizz.hpp
@@ -152,6 +152,7 @@ static const t_char GRIZZ_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = GRIZZ_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/gundren_rockseeker.hpp
+++ b/gundren_rockseeker.hpp
@@ -149,6 +149,7 @@ static const    t_char GUNDREN_ROCKSEEKER_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = GUNDREN_ROCKSEEKER_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/hilda_stormshield.hpp
+++ b/hilda_stormshield.hpp
@@ -149,6 +149,7 @@ static const    t_char HILDA_STORMSHIELD_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = HILDA_STORMSHIELD_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/initialize.hpp
+++ b/initialize.hpp
@@ -163,6 +163,13 @@ static const    t_stats INITIALIZE_STATS =
     .cha = -1,
 };
 
+static const    t_position INITIALIZE_POSITION =
+{
+    .x = 0,
+    .y = 0,
+    .z = 0,
+};
+
 static const    t_concentration INITIALIZE_CONCENTRATION =
 {
     .concentration = 0,

--- a/initialize_key_value_pairs.cpp
+++ b/initialize_key_value_pairs.cpp
@@ -22,6 +22,9 @@ int initialize_stat_key_value_pairs(t_char *info)
     tree_node_insert(node, CHA_KEY, &info->stats.cha, -1);
     tree_node_insert(node, TURN_KEY, &info->stats.turn, -1);
     tree_node_insert(node, INITIATIVE_KEY, &info->initiative, -1);
+    tree_node_insert(node, POSITION_X_KEY, &info->position.x, -1);
+    tree_node_insert(node, POSITION_Y_KEY, &info->position.y, -1);
+    tree_node_insert(node, POSITION_Z_KEY, &info->position.z, -1);
     tree_node_insert(node, BLESS_DUR_KEY, &info->bufs.bless.duration, 0);
     tree_node_insert(node, PHASE_KEY, &info->stats.phase, -1);
     tree_node_insert(node, LIGHTNING_STRIKE_DUR_KEY, &info->bufs.lightning_strike.duration, 0);

--- a/key_list.hpp
+++ b/key_list.hpp
@@ -52,6 +52,9 @@ constexpr bool is_valid_key(const char* str)
     X(CHA_KEY, "CHA=") \
     X(TURN_KEY, "TURN=") \
     X(INITIATIVE_KEY, "INITIATIVE=") \
+    X(POSITION_X_KEY, "POSITION_X=") \
+    X(POSITION_Y_KEY, "POSITION_Y=") \
+    X(POSITION_Z_KEY, "POSITION_Z=") \
     X(BLESS_DUR_KEY, "BLESS_DUR=") \
     X(PHASE_KEY, "PHASE=") \
     X(CONCENTRATION_KEY, "CONCENTRATION=") \

--- a/malfurion.hpp
+++ b/malfurion.hpp
@@ -196,6 +196,7 @@ static const t_char MALFURION_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = MALFURION_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/mannoroth.hpp
+++ b/mannoroth.hpp
@@ -185,6 +185,7 @@ static const t_char MANNOROTH_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = MANNOROTH_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/maverick.hpp
+++ b/maverick.hpp
@@ -150,6 +150,7 @@ static const t_char MAVERICK_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = MAVERICK_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #define MAVERICK_MASS_TELEPORT "Mass Teleport: Teleport all players to random locations"\

--- a/murna_claygrip.hpp
+++ b/murna_claygrip.hpp
@@ -149,6 +149,7 @@ static const    t_char MURNA_CLAYGRIP_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = MURNA_CLAYGRIP_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/night_elven_guard.hpp
+++ b/night_elven_guard.hpp
@@ -185,6 +185,7 @@ static const t_char NIGHT_ELVEN_GUARD_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = NIGHT_ELVEN_GUARD_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/save_data.cpp
+++ b/save_data.cpp
@@ -104,6 +104,9 @@ static void ft_npc_write_file_1(t_char * info, t_stats *stats, ft_file &file)
     file.printf("%s%i\n", TURN_KEY, stats->turn);
     file.printf("%s%i\n", PHASE_KEY, stats->phase);
     file.printf("%s%i\n", INITIATIVE_KEY, info->initiative);
+    file.printf("%s%i\n", POSITION_X_KEY, info->position.x);
+    file.printf("%s%i\n", POSITION_Y_KEY, info->position.y);
+    file.printf("%s%i\n", POSITION_Z_KEY, info->position.z);
     file.printf("%s%i\n", BLESS_DUR_KEY, info->bufs.bless.duration);
     file.printf("%s%i\n", PROTECTIVE_WINDS_DUR_KEY,
             info->bufs.protective_winds.duration);

--- a/shadow_illusion.hpp
+++ b/shadow_illusion.hpp
@@ -184,6 +184,7 @@ static const t_char SHADOW_ILLUSION_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = SHADOW_ILLUSION_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/shield_spell_a.hpp
+++ b/shield_spell_a.hpp
@@ -184,6 +184,7 @@ static const t_char SHIELD_SPELL_A_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = SHIELD_SPELL_A_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/snow_goblin.hpp
+++ b/snow_goblin.hpp
@@ -242,6 +242,7 @@ static const t_char SNOW_GOBLIN_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = SNOW_GOBLIN_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/snow_goblin_shaman.hpp
+++ b/snow_goblin_shaman.hpp
@@ -185,6 +185,7 @@ static const t_char SNOW_GOBLIN_SHAMAN_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = SNOW_GOBLIN_SHAMAN_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/template.hpp
+++ b/template.hpp
@@ -184,6 +184,7 @@ static const t_char TEMPLATE_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = TEMPLATE_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>

--- a/thorbald_ironpocket.hpp
+++ b/thorbald_ironpocket.hpp
@@ -149,6 +149,7 @@ static const    t_char THORBALD_IRONPOCKET_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = THORBALD_IRONPOCKET_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #endif

--- a/veraak.hpp
+++ b/veraak.hpp
@@ -204,6 +204,7 @@ static const t_char VERAAK_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = VERAAK_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 #define CHAOS_SMASH "Veraak conjures a hammer made out of dark energy hitting his" \

--- a/xavius.hpp
+++ b/xavius.hpp
@@ -185,6 +185,7 @@ static const t_char XAVIUS_INFO =
     .feats = INITIALIZE_FEATS,
     .struct_name = ft_nullptr,
     .physical = XAVIUS_PHYSICAL,
+    .position = INITIALIZE_POSITION,
 };
 
 template <int Amount, int Faces>


### PR DESCRIPTION
## Summary
- Move position into reusable `t_position` struct and add `INITIALIZE_POSITION` macro
- Persist and validate new z-axis alongside existing limits
- Default all characters to zeroed 3D positions using shared macro

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68aed1dc30e48331aaffacbda17b0e87