### PR TITLE
Add position coordinates to player saves

### DIFF
--- a/initiative_pc.cpp
+++ b/initiative_pc.cpp
@@ -3,6 +3,7 @@
 #include "libft/CPP_class/nullptr.hpp"
 #include "libft/Libft/libft.hpp"
 #include "dnd_tools.hpp"
+#include "key_list.hpp"
 #include <cstdlib>
 #include <cstring>
 
@@ -48,6 +49,9 @@ int ft_check_stat_pc(t_pc *player, char **content, char *filename)
 
     player->name = ft_nullptr;
     player->initiative = -1;
+    player->position.x = -1;
+    player->position.y = -1;
+    player->position.z = -1;
     player->next = ft_nullptr;
     while (content[line_index])
     {
@@ -66,6 +70,15 @@ int ft_check_stat_pc(t_pc *player, char **content, char *filename)
             if (!player->name)
                 return (1);
         }
+        else if (ft_strncmp(content[line_index], POSITION_X_KEY, static_cast<int>(constexpr_strlen(POSITION_X_KEY))) == 0
+                && player->position.x == -1)
+            player->position.x = ft_check_int(content[line_index], static_cast<int>(constexpr_strlen(POSITION_X_KEY)), filename);
+        else if (ft_strncmp(content[line_index], POSITION_Y_KEY, static_cast<int>(constexpr_strlen(POSITION_Y_KEY))) == 0
+                && player->position.y == -1)
+            player->position.y = ft_check_int(content[line_index], static_cast<int>(constexpr_strlen(POSITION_Y_KEY)), filename);
+        else if (ft_strncmp(content[line_index], POSITION_Z_KEY, static_cast<int>(constexpr_strlen(POSITION_Z_KEY))) == 0
+                && player->position.z == -1)
+            player->position.z = ft_check_int(content[line_index], static_cast<int>(constexpr_strlen(POSITION_Z_KEY)), filename);
         else
         {
             pf_printf_fd(2, "3-There is an error with the line: %s\n", content[line_index]);
@@ -76,6 +89,21 @@ int ft_check_stat_pc(t_pc *player, char **content, char *filename)
     if (!(player->initiative >= 0 && player->initiative <= 50))
     {
         pf_printf_fd(2, "Initiative value not found: %d\n", player->initiative);
+        return (1);
+    }
+    if (!(player->position.x >= 0 && player->position.x <= MAX_COORDINATE))
+    {
+        pf_printf_fd(2, "Position X value not found: %d\n", player->position.x);
+        return (1);
+    }
+    if (!(player->position.y >= 0 && player->position.y <= MAX_COORDINATE))
+    {
+        pf_printf_fd(2, "Position Y value not found: %d\n", player->position.y);
+        return (1);
+    }
+    if (!(player->position.z >= 0 && player->position.z <= MAX_COORDINATE))
+    {
+        pf_printf_fd(2, "Position Z value not found: %d\n", player->position.z);
         return (1);
     }
     if (!player->name)

--- a/initiative_sort_1.cpp
+++ b/initiative_sort_1.cpp
@@ -47,6 +47,9 @@ static void ft_initiative_players_init(t_pc *players)
     players->next = ft_nullptr;
     players->name = ft_nullptr;
     players->initiative = -2;
+    players->position.x = 0;
+    players->position.y = 0;
+    players->position.z = 0;
     return ;
 }
 

--- a/player.cpp
+++ b/player.cpp
@@ -74,6 +74,9 @@ void    ft_player(const char **input)
                 return ;
             }
             player->initiative = 0;
+            player->position.x = 0;
+            player->position.y = 0;
+            player->position.z = 0;
             ft_add_player(player);
         }
         else if (ft_strcmp_dnd(input[0], "list"))

--- a/player_character.hpp
+++ b/player_character.hpp
@@ -1,13 +1,16 @@
 #ifndef PLAYER_CHARACTER_H
 # define PLAYER_CHARACTER_H
 
+# include "character.hpp"
+
 typedef struct    s_pc t_pc;
 
 typedef struct    s_pc
 {
-    char    *name;
-    int        initiative;
-    t_pc    *next;
+    char        *name;
+    int         initiative;
+    t_position  position;
+    t_pc        *next;
 } t_pc;
 
 #endif

--- a/save_player.cpp
+++ b/save_player.cpp
@@ -1,10 +1,14 @@
 #include "dnd_tools.hpp"
 #include "libft/CPP_class/file.hpp"
 #include "libft/Printf/printf.hpp"
+#include "key_list.hpp"
 
 void    ft_save_pc(t_pc *player, ft_file &file)
 {
     pf_printf_fd(file, "NAME=%s\n", player->name);
     pf_printf_fd(file, "INITIATIVE=%d\n", player->initiative);
+    pf_printf_fd(file, "%s%d\n", POSITION_X_KEY, player->position.x);
+    pf_printf_fd(file, "%s%d\n", POSITION_Y_KEY, player->position.y);
+    pf_printf_fd(file, "%s%d\n", POSITION_Z_KEY, player->position.z);
     return ;
 }


### PR DESCRIPTION
## Summary
- track player x/y/z position in `t_pc`
- persist and load player position alongside name and initiative
- initialize new players with default position

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68aeddab6b94833189f1931c7174aeef