### PR TITLE
Refactor to meet coding style guidelines

### DIFF
--- a/key_list.hpp
+++ b/key_list.hpp
@@ -8,7 +8,7 @@ constexpr std::size_t constexpr_strlen(const char* str)
     std::size_t len = 0;
     while (str[len] != '\0')
         ++len;
-    return len;
+    return (len);
 }
 
 constexpr bool ends_with(const char* str, const char* suffix)
@@ -16,13 +16,15 @@ constexpr bool ends_with(const char* str, const char* suffix)
     std::size_t str_len = constexpr_strlen(str);
     std::size_t suffix_len = constexpr_strlen(suffix);
     if (suffix_len > str_len)
-        return false;
-    for (std::size_t i = 0; i < suffix_len; ++i)
+        return (false);
+    std::size_t i = 0;
+    while (i < suffix_len)
     {
         if (str[str_len - suffix_len + i] != suffix[i])
-            return false;
+            return (false);
+        ++i;
     }
-    return true;
+    return (true);
 }
 
 constexpr bool is_valid_key_impl(const char* str, std::size_t i)
@@ -31,13 +33,13 @@ constexpr bool is_valid_key_impl(const char* str, std::size_t i)
         return (i > 0 && str[i + 1] == '\0');
     if ((str[i] >= 'A' && str[i] <= 'Z') || (str[i] == '_') ||
         (str[i] >= '0' && str[i] <= '9'))
-        return is_valid_key_impl(str, i + 1);
-    return false;
+        return (is_valid_key_impl(str, i + 1));
+    return (false);
 }
 
 constexpr bool is_valid_key(const char* str)
 {
-    return is_valid_key_impl(str, 0);
+    return (is_valid_key_impl(str, 0));
 }
 
 #define KEY_LIST \

--- a/npc_set_stats.cpp
+++ b/npc_set_stats.cpp
@@ -9,25 +9,25 @@ static int ft_handle_int_mapping(char **content, int index, t_char * info)
         = tree_node_search(*(ft_return_main_treeNode()), content[index]);
     if (!return_value)
         return (1);
-    if (return_value->return_field_integer && (return_value->key_length != 0
-                && return_value->return_field_integer != ft_nullptr)
-                && ((return_value->unset_value == -1
-                || *(return_value->return_field_integer) == return_value->unset_value)))
+    if (return_value->_return_field_integer && (return_value->_key_length != 0
+                && return_value->_return_field_integer != ft_nullptr)
+                && ((return_value->_unset_value == -1
+                || *(return_value->_return_field_integer) == return_value->_unset_value)))
     {
-        *(return_value->return_field_integer) = ft_check_stat(info, content[index],
-                return_value->key_length);
+        *(return_value->_return_field_integer) = ft_check_stat(info, content[index],
+                return_value->_key_length);
         return (0);
     }
-    else if (return_value->return_field_double)
+    else if (return_value->_return_field_double)
     {
-        *return_value->return_field_double = ft_set_stats_con_targets(content[index],
-                return_value->key_length, *return_value->return_field_double, info);
+        *return_value->_return_field_double = ft_set_stats_con_targets(content[index],
+                return_value->_key_length, *return_value->_return_field_double, info);
         return (0);
     }
-    else if (return_value->return_field_string)
+    else if (return_value->_return_field_string)
     {
-        ft_set_stat_player(return_value->key_length,
-                const_cast<const char **>(return_value->return_field_string), content[index]);
+        ft_set_stat_player(return_value->_key_length,
+                const_cast<const char **>(return_value->_return_field_string), content[index]);
         return (0);
     }
     return (1);

--- a/treeNode.cpp
+++ b/treeNode.cpp
@@ -9,9 +9,9 @@ TreeNode *tree_node_new(void)
     TreeNode *node = static_cast<TreeNode *>(cma_malloc(sizeof(TreeNode)));
     if (!node)
         return (ft_nullptr);
-    new (&node->children) ft_unord_map<char, TreeNode*>();
-    node->data  = ft_nullptr;
-    node->error = 0;
+    new (&node->_children) ft_unord_map<char, TreeNode*>();
+    node->_data  = ft_nullptr;
+    node->_error = 0;
     return (node);
 }
 
@@ -19,21 +19,23 @@ void tree_node_delete(TreeNode *node)
 {
     if (!node)
         return ;
-    for (auto &pair : node->children)
+    auto it = node->_children.begin();
+    while (it != node->_children.end())
     {
-        tree_node_delete(pair.second);
+        tree_node_delete(it->second);
+        ++it;
     }
-    node->children.~ft_unord_map<char, TreeNode*>();
-    if (node->data)
-        cma_free(node->data);
+    node->_children.~ft_unord_map<char, TreeNode*>();
+    if (node->_data)
+        cma_free(node->_data);
     cma_free(node);
     return ;
 }
 
 static int tree_node_insert_helper(TreeNode *node, const char *key, int unset_value,
-                              int *intVal, char **strVal, char ***dblVal)
+                              int *int_val, char **str_val, char ***dbl_val)
 {
-    if (node->error)
+    if (node->_error)
         return (1);
     size_t length = ft_strlen_size_t(key);
     TreeNode *current = node;
@@ -41,33 +43,33 @@ static int tree_node_insert_helper(TreeNode *node, const char *key, int unset_va
     while (*ptr)
     {
         char ch = *ptr++;
-        if (!current->children[ch])
+        if (!current->_children[ch])
         {
             TreeNode *child = tree_node_new();
             if (!child)
             {
-                node->error = 1;
+                node->_error = 1;
                 return (1);
             }
-            current->children[ch] = child;
+            current->_children[ch] = child;
         }
-        current = current->children[ch];
+        current = current->_children[ch];
     }
-    if (!current->data)
+    if (!current->_data)
     {
-        current->data = static_cast<t_treeNode_value *>(cma_malloc(sizeof(t_treeNode_value)));
-        if (!current->data)
+        current->_data = static_cast<t_treeNode_value *>(cma_malloc(sizeof(t_treeNode_value)));
+        if (!current->_data)
         {
-            node->error = 1;
+            node->_error = 1;
             return (1);
         }
     }
-    ft_bzero(current->data, sizeof(t_treeNode_value));
-    current->data->unset_value           = unset_value;
-    current->data->key_length            = length;
-    current->data->return_field_integer  = intVal;
-    current->data->return_field_string   = strVal;
-    current->data->return_field_double   = dblVal;
+    ft_bzero(current->_data, sizeof(t_treeNode_value));
+    current->_data->_unset_value           = unset_value;
+    current->_data->_key_length            = length;
+    current->_data->_return_field_integer  = int_val;
+    current->_data->_return_field_string   = str_val;
+    current->_data->_return_field_double   = dbl_val;
     return (0);
 }
 
@@ -88,32 +90,32 @@ int tree_node_insert(TreeNode *node, const char *key, char ***value)
 
 const t_treeNode_value *tree_node_search(const TreeNode *node, const char *key)
 {
-    if (node->error)
+    if (node->_error)
         return (ft_nullptr);
     const TreeNode *current = node;
     while (*key != '=')
     {
-        auto it = current->children.find(*key);
-        if (it == current->children.end())
+        auto it = current->_children.find(*key);
+        if (it == current->_children.end())
             return (ft_nullptr);
         current = it->second;
         key++;
     }
     if (*key == '=')
     {
-        auto it = current->children.find(*key);
-        if (it == current->children.end())
+        auto it = current->_children.find(*key);
+        if (it == current->_children.end())
             return (ft_nullptr);
         current = it->second;
         key++;
     }
     else
         return (ft_nullptr);
-    return (current->data);
+    return (current->_data);
 }
 
 int tree_node_get_error(const TreeNode *node)
 {
-    return (node->error);
+    return (node->_error);
 }
 

--- a/treeNode.hpp
+++ b/treeNode.hpp
@@ -10,18 +10,18 @@
 
 typedef struct s_treeNode_value
 {
-    size_t   key_length;
-    int       unset_value;
-    int       *return_field_integer;
-    char      **return_field_string;
-    char      ***return_field_double;
+    size_t   _key_length;
+    int       _unset_value;
+    int       *_return_field_integer;
+    char      **_return_field_string;
+    char      ***_return_field_double;
 } t_treeNode_value;
 
 typedef struct s_treeNode
 {
-    t_treeNode_value *data;
-    int error;
-    ft_unord_map<char, struct s_treeNode*> children;
+    t_treeNode_value *_data;
+    int _error;
+    ft_unord_map<char, struct s_treeNode*> _children;
 } TreeNode;
 
 // Function declarations for creating/destroying nodes:


### PR DESCRIPTION
## Summary
- Prefix `TreeNode` and `t_treeNode_value` members with underscores to follow naming conventions
- Update tree node operations and NPC stat handling to use underscore-prefixed members

## Testing
- `make` *(fails: comparing floating-point with == or != is unsafe)*

------
https://chatgpt.com/codex/tasks/task_e_68bc4c23ee30833191a87e64616e5405