### PR TITLE
Refactor ft_check_value to use libft validator

### DIFF
--- a/utils01.cpp
+++ b/utils01.cpp
@@ -1,31 +1,6 @@
 #include "dnd_tools.hpp"
-#include <limits>
 
 int    ft_check_value(const char *input)
 {
-    long    number = 0;
-    int        index = 0;
-    int        sign = 1;
-
-    if (input[index] == '+' || input[index] == '-')
-        index++;
-    if (!input[index])
-        return (1);
-    if (input[0] == '-')
-        sign = -1;
-    while (input[index])
-    {
-        if (input[index] >= '0' && input[index] <= '9')
-        {
-            number = (number * 10) + input[index] - '0';
-            long signed_number = sign * number;
-            if (signed_number < std::numeric_limits<int>::min()
-                    || signed_number > std::numeric_limits<int>::max())
-                return (2);
-            index++;
-        }
-        else
-            return (3);
-    }
-    return (0);
+    return (ft_validate_int(input));
 }


### PR DESCRIPTION
## Summary
- replace the manual integer parsing in ft_check_value with a call to libft's ft_validate_int helper
- drop the now-unused <limits> include from utils01.cpp

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cd347606b08331a0f4b5b91c7d2785