### PR TITLE
Refactor ft_strtrim_prefix duplication logic

### DIFF
--- a/trim_start.cpp
+++ b/trim_start.cpp
@@ -1,33 +1,7 @@
 #include "dnd_tools.hpp"
-#include <cstdlib>
-#include <cstring>
 #include "libft/CMA/CMA.hpp"
 #include "libft/Libft/libft.hpp"
 #include "libft/CPP_class/class_nullptr.hpp"
-
-static size_t str_len(const char *str)
-{
-    size_t i = 0;
-
-    while (str[i])
-        i++;
-    return (i);
-}
-
-static char *str_new(size_t n)
-{
-    char *str = static_cast<char *>(cma_malloc(sizeof(char) * (n + 1)));
-
-    if (!str)
-        return (ft_nullptr);
-    size_t index = 0;
-    while (index <= n)
-    {
-        str[index] = '\0';
-        index++;
-    }
-    return (str);
-}
 
 char *ft_strtrim_prefix(const char *s1, const char *prefix)
 {
@@ -37,22 +11,17 @@ char *ft_strtrim_prefix(const char *s1, const char *prefix)
 
     if (!s1 || !prefix)
         return (ft_nullptr);
-    prefix_len = str_len(prefix);
-    s1_len = str_len(s1);
-
-    if (ft_strncmp(s1, prefix, prefix_len) == 0)
+    prefix_len = ft_strlen_size_t(prefix);
+    s1_len = ft_strlen_size_t(s1);
+    if (prefix_len <= s1_len && ft_strncmp(s1, prefix, prefix_len) == 0)
     {
-        trimmed_str = str_new(s1_len - prefix_len);
+        trimmed_str = cma_strdup(s1 + prefix_len);
         if (!trimmed_str)
             return (ft_nullptr);
-        strcpy(trimmed_str, s1 + prefix_len);
+        return (trimmed_str);
     }
-    else
-    {
-        trimmed_str = str_new(s1_len);
-        if (!trimmed_str)
-            return (ft_nullptr);
-        strcpy(trimmed_str, s1);
-    }
+    trimmed_str = cma_strdup(s1);
+    if (!trimmed_str)
+        return (ft_nullptr);
     return (trimmed_str);
 }


### PR DESCRIPTION
## Summary
- simplify ft_strtrim_prefix by removing local helper functions and using ft_strlen_size_t for length checks
- duplicate the appropriate substring via cma_strdup and handle allocation failures consistently
- drop unused standard headers that supported the removed helpers

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cd380dfa308331967c4e734729f049