### PR TITLE
Add automated tests and test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ endif
 
 NAME        = dnd_tools$(EXE_EXT)
 NAME_DEBUG  = dnd_tools_debug$(EXE_EXT)
+TEST_NAME   = automated_tests$(EXE_EXT)
 
 HEADER      = dnd_tools.hpp \
               character.hpp \
@@ -230,6 +231,7 @@ LIBFT_DIR   = ./libft
 
 OBJ_DIR         = ./objs
 OBJ_DIR_DEBUG   = ./objs_debug
+OBJ_DIR_TEST    = ./objs_tests
 
 ENABLE_LTO  ?= 0
 ENABLE_PGO  ?= 0
@@ -264,11 +266,22 @@ endif
 
 OBJS        = $(SRC:%.cpp=$(OBJ_DIR)/%.o)
 
+TEST_SRC    = tests/automated_tests.cpp \
+              trim_start.cpp \
+              ordinal_suffix.cpp \
+              roll_validate_string.cpp \
+              roll_validate_utils.cpp
+
+TEST_OBJS   = $(TEST_SRC:%.cpp=$(OBJ_DIR_TEST)/%.o)
+
 all: dirs $(TARGET)
+
+tests: dirs $(TEST_NAME)
 
 dirs:
 	-$(MKDIR) $(OBJ_DIR)
 	-$(MKDIR) $(OBJ_DIR_DEBUG)
+	-$(MKDIR) $(OBJ_DIR_TEST)
 
 debug:
 	$(MAKE) all DEBUG=1
@@ -276,24 +289,35 @@ debug:
 $(TARGET): $(LIBFT) $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LDFLAGS)
 
+$(TEST_NAME): $(LIBFT) $(TEST_OBJS)
+	$(CC) $(CFLAGS) $(TEST_OBJS) -o $@ $(LDFLAGS)
+
 $(LIBFT):
 	$(MAKE) -C $(LIBFT_DIR) $(if $(DEBUG), debug)
 
 $(OBJ_DIR)/%.o: %.cpp $(HEADER)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+$(OBJ_DIR_TEST)/%.o: %.cpp $(HEADER)
+	-$(MKDIR) $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@
+
 clean:
 	-$(RM) $(OBJ_DIR)/*.o $(OBJ_DIR_DEBUG)/*.o
+	-$(RM) $(OBJ_DIR_TEST)/*.o $(OBJ_DIR_TEST)/tests/*.o
 	$(MAKE) -C $(LIBFT_DIR) fclean
 
 fclean: clean
-	-$(RM) $(NAME) $(NAME_DEBUG)
-	-$(RMDIR) $(OBJ_DIR) $(OBJ_DIR_DEBUG) data
+	-$(RM) $(NAME) $(NAME_DEBUG) $(TEST_NAME)
+	-$(RMDIR) $(OBJ_DIR) $(OBJ_DIR_DEBUG) $(OBJ_DIR_TEST) data
 
 re: fclean all
+
+test: $(TEST_NAME)
+	./$(TEST_NAME)
 
 both: all debug
 
 re_both: re both
 
-.PHONY: all dirs clean fclean re debug both re_both
+.PHONY: all dirs clean fclean re debug both re_both tests test

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -1,0 +1,95 @@
+#include "../dnd_tools.hpp"
+#include "../libft/CMA/CMA.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include <cstdio>
+#include <cstdlib>
+
+static void assert_true(int condition, const char *message)
+{
+    if (!condition)
+    {
+        std::fprintf(stderr, "Test failed: %s\n", message);
+        cma_cleanup();
+        std::exit(1);
+    }
+    return ;
+}
+
+static void test_strtrim_prefix_removes_prefix()
+{
+    char *result;
+
+    result = ft_strtrim_prefix("prefix_value", "prefix_");
+    assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for valid prefix");
+    assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix did not remove prefix");
+    cma_free(result);
+    return ;
+}
+
+static void test_strtrim_prefix_without_match_returns_copy()
+{
+    char *result;
+
+    result = ft_strtrim_prefix("value", "prefix_");
+    assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for missing prefix");
+    assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix changed string without prefix match");
+    cma_free(result);
+    return ;
+}
+
+static void test_strtrim_prefix_handles_null_input()
+{
+    char *result;
+
+    result = ft_strtrim_prefix(ft_nullptr, "prefix_");
+    assert_true(result == ft_nullptr, "ft_strtrim_prefix should return null when source is null");
+    return ;
+}
+
+static void test_ordinal_suffix_values()
+{
+    const char *suffix;
+
+    suffix = ft_ordinal_suffix(1);
+    assert_true(ft_strcmp(suffix, "first") == 0, "ordinal suffix for 1 should be first");
+    suffix = ft_ordinal_suffix(2);
+    assert_true(ft_strcmp(suffix, "second") == 0, "ordinal suffix for 2 should be second");
+    suffix = ft_ordinal_suffix(3);
+    assert_true(ft_strcmp(suffix, "third") == 0, "ordinal suffix for 3 should be third");
+    suffix = ft_ordinal_suffix(21);
+    assert_true(ft_strcmp(suffix, "nth") == 0, "ordinal suffix for numbers above table should be nth");
+    return ;
+}
+
+static void test_command_roll_validate_accepts_valid_expression()
+{
+    char expression[] = "2d6+3";
+    int result;
+
+    result = ft_command_roll_validate(expression);
+    assert_true(result == 0, "ft_command_roll_validate rejected a valid roll expression");
+    return ;
+}
+
+static void test_command_roll_validate_rejects_mismatched_parenthesis()
+{
+    char expression[] = "2d6+3)";
+    int result;
+
+    result = ft_command_roll_validate(expression);
+    assert_true(result != 0, "ft_command_roll_validate accepted an invalid roll expression");
+    return ;
+}
+
+int main()
+{
+    test_strtrim_prefix_removes_prefix();
+    test_strtrim_prefix_without_match_returns_copy();
+    test_strtrim_prefix_handles_null_input();
+    test_ordinal_suffix_values();
+    test_command_roll_validate_accepts_valid_expression();
+    test_command_roll_validate_rejects_mismatched_parenthesis();
+    cma_cleanup();
+    std::printf("All tests passed.\n");
+    return (0);
+}


### PR DESCRIPTION
## Summary
- add an automated test executable that exercises string trimming, ordinal suffix, and roll validation helpers
- extend the Makefile with a reusable `make test` target and supporting object directory for the new tests

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cd3ac381b4833198f96f06840c051c