### PR TITLE
Use helper to free split input

### DIFF
--- a/free_memory.cpp
+++ b/free_memory.cpp
@@ -6,13 +6,7 @@
 
 void    ft_free_input(char **input, char *input_string)
 {
-    int    index = 0;
-    while (input[index])
-    {
-        cma_free(input[index]);
-        index++;
-    }
-    cma_free(input);
+    cma_free_double(input);
     cma_free(input_string);
 }
 


### PR DESCRIPTION
## Summary
- replace the manual cleanup loop in `ft_free_input` with `cma_free_double`
- verified that the input parser uses `cma_split`, which produces null-terminated arrays for safe freeing

## Testing
- make test *(fails: tests reference missing `ft_command_roll_validate` symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3ee064f08331914cdc2225b463c6