### PR TITLE
Expand automated tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,10 +259,15 @@ endif
 OBJS        = $(SRC:%.cpp=$(OBJ_DIR)/%.o)
 
 TEST_SRC    = tests/automated_tests.cpp \
+              tests/test_support.cpp \
+              tests/string_prefix_tests.cpp \
+              tests/ordinal_suffix_tests.cpp \
+              tests/roll_validation_tests.cpp \
+              tests/create_data_folder_tests.cpp \
               trim_start.cpp \
               ordinal_suffix.cpp \
-              roll_validate_string.cpp \
-              roll_validate_utils.cpp
+              roll.cpp \
+              create_data_folder.cpp
 
 TEST_OBJS   = $(TEST_SRC:%.cpp=$(OBJ_DIR_TEST)/%.o)
 

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -481,6 +481,7 @@ void        ft_initiative_add(t_char * info);
 
 // Command roll
 int         *ft_command_roll(char **argv);
+int         ft_command_roll_validate(char *expression);
 
 // Player
 void        ft_player(const char **input);

--- a/roll.cpp
+++ b/roll.cpp
@@ -5,6 +5,8 @@
 #include "libft/Errno/errno.hpp"
 #include "libft/Math/roll.hpp"
 
+int math_roll_validate(char *string);
+
 int *ft_command_roll(char **argv)
 {
     char    *expression;
@@ -38,4 +40,23 @@ int *ft_command_roll(char **argv)
         return (ft_nullptr);
     ft_errno = ER_SUCCESS;
     return (value);
+}
+
+int ft_command_roll_validate(char *expression)
+{
+    int validation_result;
+
+    if (!expression)
+    {
+        ft_errno = FT_EINVAL;
+        return (1);
+    }
+    validation_result = math_roll_validate(expression);
+    if (validation_result == 0)
+    {
+        ft_errno = ER_SUCCESS;
+        return (0);
+    }
+    ft_errno = FT_EINVAL;
+    return (validation_result);
 }

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -1,94 +1,15 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
 #include "../dnd_tools.hpp"
 #include "../libft/CMA/CMA.hpp"
-#include "../libft/CPP_class/class_nullptr.hpp"
 #include <cstdio>
-#include <cstdlib>
-
-static void assert_true(int condition, const char *message)
-{
-    if (!condition)
-    {
-        std::fprintf(stderr, "Test failed: %s\n", message);
-        cma_cleanup();
-        std::exit(1);
-    }
-    return ;
-}
-
-static void test_strtrim_prefix_removes_prefix()
-{
-    char *result;
-
-    result = ft_strtrim_prefix("prefix_value", "prefix_");
-    assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for valid prefix");
-    assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix did not remove prefix");
-    cma_free(result);
-    return ;
-}
-
-static void test_strtrim_prefix_without_match_returns_copy()
-{
-    char *result;
-
-    result = ft_strtrim_prefix("value", "prefix_");
-    assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for missing prefix");
-    assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix changed string without prefix match");
-    cma_free(result);
-    return ;
-}
-
-static void test_strtrim_prefix_handles_null_input()
-{
-    char *result;
-
-    result = ft_strtrim_prefix(ft_nullptr, "prefix_");
-    assert_true(result == ft_nullptr, "ft_strtrim_prefix should return null when source is null");
-    return ;
-}
-
-static void test_ordinal_suffix_values()
-{
-    const char *suffix;
-
-    suffix = ft_ordinal_suffix(1);
-    assert_true(ft_strcmp(suffix, "first") == 0, "ordinal suffix for 1 should be first");
-    suffix = ft_ordinal_suffix(2);
-    assert_true(ft_strcmp(suffix, "second") == 0, "ordinal suffix for 2 should be second");
-    suffix = ft_ordinal_suffix(3);
-    assert_true(ft_strcmp(suffix, "third") == 0, "ordinal suffix for 3 should be third");
-    suffix = ft_ordinal_suffix(21);
-    assert_true(ft_strcmp(suffix, "nth") == 0, "ordinal suffix for numbers above table should be nth");
-    return ;
-}
-
-static void test_command_roll_validate_accepts_valid_expression()
-{
-    char expression[] = "2d6+3";
-    int result;
-
-    result = ft_command_roll_validate(expression);
-    assert_true(result == 0, "ft_command_roll_validate rejected a valid roll expression");
-    return ;
-}
-
-static void test_command_roll_validate_rejects_mismatched_parenthesis()
-{
-    char expression[] = "2d6+3)";
-    int result;
-
-    result = ft_command_roll_validate(expression);
-    assert_true(result != 0, "ft_command_roll_validate accepted an invalid roll expression");
-    return ;
-}
 
 int main()
 {
-    test_strtrim_prefix_removes_prefix();
-    test_strtrim_prefix_without_match_returns_copy();
-    test_strtrim_prefix_handles_null_input();
-    test_ordinal_suffix_values();
-    test_command_roll_validate_accepts_valid_expression();
-    test_command_roll_validate_rejects_mismatched_parenthesis();
+    run_string_prefix_tests();
+    run_ordinal_suffix_tests();
+    run_roll_validation_tests();
+    run_create_data_folder_tests();
     cma_cleanup();
     std::printf("All tests passed.\n");
     return (0);

--- a/tests/create_data_folder_tests.cpp
+++ b/tests/create_data_folder_tests.cpp
@@ -1,0 +1,75 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include "../libft/Errno/errno.hpp"
+#include "../libft/File/file_utils.hpp"
+#include "../libft/File/open_dir.hpp"
+#include "../libft/System_utils/system_utils.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include <filesystem>
+#include <system_error>
+#include <cstdio>
+#include <fcntl.h>
+
+static void remove_data_path()
+{
+    std::error_code remove_error;
+
+    std::filesystem::remove_all("data", remove_error);
+    if (remove_error.value() != 0)
+        std::remove("data");
+    return ;
+}
+
+static void test_create_data_dir_creates_directory_when_missing()
+{
+    int result;
+
+    remove_data_path();
+    result = ft_create_data_dir();
+    test_assert_true(result == 0, "ft_create_data_dir should create missing data directory");
+    test_assert_true(file_dir_exists("data") == 0, "ft_create_data_dir did not create the data directory");
+    test_assert_true(ft_errno == ER_SUCCESS, "ft_create_data_dir should set errno to success after creating directory");
+    remove_data_path();
+    return ;
+}
+
+static void test_create_data_dir_handles_existing_directory()
+{
+    int result;
+
+    remove_data_path();
+    test_assert_true(file_create_directory("data", 0700) == 0, "failed to create directory for setup");
+    result = ft_create_data_dir();
+    test_assert_true(result == 0, "ft_create_data_dir should succeed when directory already exists");
+    test_assert_true(ft_errno == ER_SUCCESS, "ft_create_data_dir should leave errno as success when directory exists");
+    remove_data_path();
+    return ;
+}
+
+static void test_create_data_dir_reports_file_collision()
+{
+    su_file *file_handle;
+    int result;
+
+    remove_data_path();
+    file_handle = su_fopen("data", O_CREAT | O_RDWR, 0600);
+    test_assert_true(file_handle != ft_nullptr, "failed to create file for collision test");
+    if (file_handle != ft_nullptr)
+        test_assert_true(su_fclose(file_handle) == 0, "failed to close collision file");
+    result = ft_create_data_dir();
+    test_assert_true(result == 1, "ft_create_data_dir should fail when path is a file");
+    test_assert_true(ft_errno == ER_SUCCESS, "ft_create_data_dir should not modify errno for collision case");
+    test_assert_true(file_exists("data") == 1, "collision file should remain after failure");
+    test_assert_true(file_delete("data") == 0, "failed to delete collision file");
+    return ;
+}
+
+void run_create_data_folder_tests()
+{
+    test_create_data_dir_creates_directory_when_missing();
+    test_create_data_dir_handles_existing_directory();
+    test_create_data_dir_reports_file_collision();
+    remove_data_path();
+    return ;
+}

--- a/tests/ordinal_suffix_tests.cpp
+++ b/tests/ordinal_suffix_tests.cpp
@@ -1,0 +1,38 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+
+static void test_ordinal_suffix_values()
+{
+    const char *suffix;
+
+    suffix = ft_ordinal_suffix(1);
+    test_assert_true(ft_strcmp(suffix, "first") == 0, "ordinal suffix for 1 should be first");
+    suffix = ft_ordinal_suffix(2);
+    test_assert_true(ft_strcmp(suffix, "second") == 0, "ordinal suffix for 2 should be second");
+    suffix = ft_ordinal_suffix(3);
+    test_assert_true(ft_strcmp(suffix, "third") == 0, "ordinal suffix for 3 should be third");
+    suffix = ft_ordinal_suffix(21);
+    test_assert_true(ft_strcmp(suffix, "nth") == 0, "ordinal suffix for numbers above table should be nth");
+    return ;
+}
+
+static void test_ordinal_suffix_handles_teens()
+{
+    const char *suffix;
+
+    suffix = ft_ordinal_suffix(11);
+    test_assert_true(ft_strcmp(suffix, "eleventh") == 0, "ordinal suffix for 11 should be eleventh");
+    suffix = ft_ordinal_suffix(12);
+    test_assert_true(ft_strcmp(suffix, "twelfth") == 0, "ordinal suffix for 12 should be twelfth");
+    suffix = ft_ordinal_suffix(13);
+    test_assert_true(ft_strcmp(suffix, "thirteenth") == 0, "ordinal suffix for 13 should be thirteenth");
+    return ;
+}
+
+void run_ordinal_suffix_tests()
+{
+    test_ordinal_suffix_values();
+    test_ordinal_suffix_handles_teens();
+    return ;
+}

--- a/tests/roll_validation_tests.cpp
+++ b/tests/roll_validation_tests.cpp
@@ -1,0 +1,45 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include "../libft/Errno/errno.hpp"
+
+static void test_command_roll_validate_accepts_valid_expression()
+{
+    char expression[] = "2d6+3";
+    int result;
+
+    result = ft_command_roll_validate(expression);
+    test_assert_true(result == 0, "ft_command_roll_validate rejected a valid roll expression");
+    test_assert_true(ft_errno == ER_SUCCESS, "ft_command_roll_validate should set errno to success on valid expression");
+    return ;
+}
+
+static void test_command_roll_validate_rejects_mismatched_parenthesis()
+{
+    char expression[] = "2d6+3)";
+    int result;
+
+    result = ft_command_roll_validate(expression);
+    test_assert_true(result != 0, "ft_command_roll_validate accepted an invalid roll expression");
+    test_assert_true(ft_errno == FT_EINVAL, "ft_command_roll_validate should set errno to FT_EINVAL on invalid input");
+    return ;
+}
+
+static void test_command_roll_validate_handles_null_expression()
+{
+    int result;
+
+    result = ft_command_roll_validate(ft_nullptr);
+    test_assert_true(result != 0, "ft_command_roll_validate should fail when expression is null");
+    test_assert_true(ft_errno == FT_EINVAL, "ft_command_roll_validate should set errno to FT_EINVAL when expression is null");
+    return ;
+}
+
+void run_roll_validation_tests()
+{
+    test_command_roll_validate_accepts_valid_expression();
+    test_command_roll_validate_rejects_mismatched_parenthesis();
+    test_command_roll_validate_handles_null_expression();
+    return ;
+}

--- a/tests/string_prefix_tests.cpp
+++ b/tests/string_prefix_tests.cpp
@@ -1,0 +1,56 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include "../libft/CMA/CMA.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+
+static void test_strtrim_prefix_removes_prefix()
+{
+    char *result;
+
+    result = ft_strtrim_prefix("prefix_value", "prefix_");
+    test_assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for valid prefix");
+    test_assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix did not remove prefix");
+    cma_free(result);
+    return ;
+}
+
+static void test_strtrim_prefix_without_match_returns_copy()
+{
+    char *result;
+
+    result = ft_strtrim_prefix("value", "prefix_");
+    test_assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for missing prefix");
+    test_assert_true(ft_strcmp(result, "value") == 0, "ft_strtrim_prefix changed string without prefix match");
+    cma_free(result);
+    return ;
+}
+
+static void test_strtrim_prefix_handles_null_input()
+{
+    char *result;
+
+    result = ft_strtrim_prefix(ft_nullptr, "prefix_");
+    test_assert_true(result == ft_nullptr, "ft_strtrim_prefix should return null when source is null");
+    return ;
+}
+
+static void test_strtrim_prefix_returns_empty_string_for_full_match()
+{
+    char *result;
+
+    result = ft_strtrim_prefix("prefix_", "prefix_");
+    test_assert_true(result != ft_nullptr, "ft_strtrim_prefix returned null for full match");
+    test_assert_true(ft_strcmp(result, "") == 0, "ft_strtrim_prefix should return empty string when prefix consumes all characters");
+    cma_free(result);
+    return ;
+}
+
+void run_string_prefix_tests()
+{
+    test_strtrim_prefix_removes_prefix();
+    test_strtrim_prefix_without_match_returns_copy();
+    test_strtrim_prefix_handles_null_input();
+    test_strtrim_prefix_returns_empty_string_for_full_match();
+    return ;
+}

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -1,0 +1,9 @@
+#ifndef TEST_GROUPS_HPP
+# define TEST_GROUPS_HPP
+
+void    run_string_prefix_tests();
+void    run_ordinal_suffix_tests();
+void    run_roll_validation_tests();
+void    run_create_data_folder_tests();
+
+#endif

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -1,0 +1,15 @@
+#include "test_support.hpp"
+#include "../libft/CMA/CMA.hpp"
+#include <cstdio>
+#include <cstdlib>
+
+void test_assert_true(int condition, const char *message)
+{
+    if (!condition)
+    {
+        std::fprintf(stderr, "Test failed: %s\n", message);
+        cma_cleanup();
+        std::exit(1);
+    }
+    return ;
+}

--- a/tests/test_support.hpp
+++ b/tests/test_support.hpp
@@ -1,0 +1,6 @@
+#ifndef TEST_SUPPORT_HPP
+# define TEST_SUPPORT_HPP
+
+void    test_assert_true(int condition, const char *message);
+
+#endif


### PR DESCRIPTION
## Summary
- modularize the automated test runner to use shared assertions and per-feature suites
- add dedicated suites covering string prefix trimming, ordinal suffix cases, roll validation errors, and data directory handling
- register the new test files and supporting sources with the test target to build the additional coverage

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68cd404c17088331b9246a4c4156e692