### PR TITLE
Handle readline cancellation gracefully

### DIFF
--- a/cast_magic_drain.cpp
+++ b/cast_magic_drain.cpp
@@ -60,7 +60,15 @@ void    ft_cast_magic_drain(t_char *info, const char **input)
     ft_string message;
     if (generate_magic_drain_message(info, message))
         return ;
-    if (ft_readline_confirm(message))
+    int confirm;
+
+    confirm = ft_readline_confirm(message);
+    if (confirm == RL_INPUT_CANCEL)
+    {
+        pf_printf("Magic Drain cancelled.\n");
+        return ;
+    }
+    if (confirm != 0)
         return ;
     t_buff buff_info = MAKE_BUFF_MAGIC_DRAIN(info->spells.magic_drain, input[3]);
     int error = ft_cast_concentration(info, input, &buff_info);

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -24,6 +24,7 @@ static_assert(sizeof(int) == 4, "Expected int to be 4 bytes");
 # define RL_SUCCES 2
 # define RL_FAIL 3
 # define RL_CRIT_FAIL 4
+# define RL_INPUT_CANCEL 5
 
 extern bool g_dnd_test;
 

--- a/fclean.cpp
+++ b/fclean.cpp
@@ -20,13 +20,23 @@ void ft_fclean(void)
     int         status;
     const char  *command[4];
     pid_t       pid;
+    int         confirm;
 
     command[0] = "/bin/sh";
     command[1] = "-c";
     command[2] = "rm -rf ./data/*";
     command[3] = ft_nullptr;
-    if (g_dnd_test == false && ft_readline_confirm("type yes to confirm or no to abort: "))
-        return ;
+    if (g_dnd_test == false)
+    {
+        confirm = ft_readline_confirm("type yes to confirm or no to abort: ");
+        if (confirm == RL_INPUT_CANCEL)
+        {
+            pf_printf("Command cancelled.\n");
+            return ;
+        }
+        if (confirm != 0)
+            return ;
+    }
     pid = fork();
     if (pid == -1)
     {
@@ -50,8 +60,19 @@ void ft_fclean(void)
         }
     }
 #else
-    if (g_dnd_test == false && ft_readline_confirm("type yes to confirm or no to abort: "))
-        return ;
+    int confirm;
+
+    if (g_dnd_test == false)
+    {
+        confirm = ft_readline_confirm("type yes to confirm or no to abort: ");
+        if (confirm == RL_INPUT_CANCEL)
+        {
+            pf_printf("Command cancelled.\n");
+            return ;
+        }
+        if (confirm != 0)
+            return ;
+    }
     std::error_code ec;
     for (const auto &entry : std::filesystem::directory_iterator("./data", ec))
     {
@@ -71,14 +92,24 @@ void ft_clean(void)
     int         status;
     const char  *command[4];
     pid_t       pid;
+    int         confirm;
 
     command[0] = "/bin/sh";
     command[1] = "-c";
     command[2] = "find ./data -mindepth 1 -maxdepth 1 \\( ! -name 'data--*' !" \
                                   "-name 'pc--*' \\) -exec rm -rf {} +";
     command[3] = ft_nullptr;
-    if (g_dnd_test == 0 && ft_readline_confirm("type yes to confirm or no to abort: "))
-        return ;
+    if (g_dnd_test == 0)
+    {
+        confirm = ft_readline_confirm("type yes to confirm or no to abort: ");
+        if (confirm == RL_INPUT_CANCEL)
+        {
+            pf_printf("Command cancelled.\n");
+            return ;
+        }
+        if (confirm != 0)
+            return ;
+    }
     pid = fork();
     if (pid == -1)
     {
@@ -102,8 +133,19 @@ void ft_clean(void)
         }
     }
 #else
-    if (g_dnd_test == 0 && ft_readline_confirm("type yes to confirm or no to abort: "))
-        return ;
+    int confirm;
+
+    if (g_dnd_test == 0)
+    {
+        confirm = ft_readline_confirm("type yes to confirm or no to abort: ");
+        if (confirm == RL_INPUT_CANCEL)
+        {
+            pf_printf("Command cancelled.\n");
+            return ;
+        }
+        if (confirm != 0)
+            return ;
+    }
     std::error_code ec;
     for (const auto &entry : std::filesystem::directory_iterator("./data", ec))
     {

--- a/fel_poison_weapon_effects.cpp
+++ b/fel_poison_weapon_effects.cpp
@@ -16,6 +16,8 @@ void ft_fel_poison_attack_effects(t_char *info, t_equipment_id *weapon,
     if (!message)
         return ;
     int result_check = ft_readline_check_succes_or_fail(message);
+    if (result_check == RL_INPUT_CANCEL)
+        return ;
     if (result_check == RL_FAIL || result_check == RL_CRIT_FAIL)
     {
         int result = ft_dice_roll(weapon->action_01.effect_dice_amount,

--- a/help.cpp
+++ b/help.cpp
@@ -15,5 +15,6 @@ void ft_print_help(void)
     pf_printf("  add player <name>   Add a new player\n");
     pf_printf("  encounter <name>    Start encounter from file\n");
     pf_printf("  encounter xavius damage <portal|shield spell>   Deal 1 damage\n");
+    pf_printf("\nPrompts can be cancelled with Ctrl+D (EOF) without raising an error.\n");
     return ;
 }

--- a/nightmare_claw_effect.cpp
+++ b/nightmare_claw_effect.cpp
@@ -13,6 +13,9 @@ void    ft_nightmare_claw_effect(t_char *info, t_equipment_id *weapon,
     const char *message = "The target must succeed on a DC20 Charisma saving throw. Enter "
                 "\"crit succes\", \"succes\", \"fail\" or \"crit fail\": ";
     int result_check = ft_readline_check_succes_or_fail(message);
+
+    if (result_check == RL_INPUT_CANCEL)
+        return ;
     if (result_check == RL_FAIL || result_check == RL_CRIT_FAIL)
         pf_printf("The target is frightened and has disadvantage on their next turn.\n");
     else

--- a/readline_check.cpp
+++ b/readline_check.cpp
@@ -7,7 +7,7 @@
 #include "dnd_tools.hpp"
 #include <cstdlib>
 
-int    ft_readline_confirm(const char *message)
+int ft_readline_confirm(const char *message)
 {
     char    *input;
 
@@ -15,58 +15,58 @@ int    ft_readline_confirm(const char *message)
         return (ft_dice_roll(1, 2) - 1);
     while ((input = rl_readline(message)) != ft_nullptr)
     {
-        if ((ft_strcmp(input, "y") == 0) || (ft_strcmp(input, "Y") == 0) ||
-                (ft_strcmp(input, "yes") == 0))
+        if ((ft_strcmp(input, "y") == 0) || (ft_strcmp(input, "Y") == 0)
+            || (ft_strcmp(input, "yes") == 0))
         {
             cma_free(input);
             return (0);
         }
-        else if ((ft_strcmp(input, "n") == 0) || (ft_strcmp(input, "N") == 0) ||
-                (ft_strcmp(input, "no") == 0))
+        else if ((ft_strcmp(input, "n") == 0) || (ft_strcmp(input, "N") == 0)
+            || (ft_strcmp(input, "no") == 0))
         {
             cma_free(input);
             return (1);
         }
+        cma_free(input);
     }
-        pf_printf_fd(2, "116-Error: read line memory allocation failed\n");
-        return (-1);
+    return (RL_INPUT_CANCEL);
 }
 
-int     ft_readline_check_succes_or_fail(const char *message)
+int ft_readline_check_succes_or_fail(const char *message)
 {
-        char    *input;
+    char    *input;
 
-        if (g_dnd_test == true)
-                return (ft_dice_roll(1, 4));
-        while ((input = rl_readline(message)) != ft_nullptr)
+    if (g_dnd_test == true)
+        return (ft_dice_roll(1, 4));
+    while ((input = rl_readline(message)) != ft_nullptr)
+    {
+        if ((ft_strcmp(input, "crit succes") == 0)
+            || (ft_strcmp(input, "crit success") == 0))
         {
-                if ((ft_strcmp(input, "crit succes") == 0)
-                        || (ft_strcmp(input, "crit success") == 0))
-                {
-                        cma_free(input);
-                        return (RL_CRIT_SUCCES);
-                }
-                else if ((ft_strcmp(input, "succes") == 0)
-                        || (ft_strcmp(input, "success") == 0))
-                {
-                        cma_free(input);
-                        return (RL_SUCCES);
-                }
-                else if ((ft_strcmp(input, "crit fail") == 0)
-                        || (ft_strcmp(input, "critical fail") == 0))
-                {
-                        cma_free(input);
-                        return (RL_CRIT_FAIL);
-                }
-                else if ((ft_strcmp(input, "fail") == 0)
-                        || (ft_strcmp(input, "failure") == 0))
-                {
-                        cma_free(input);
-                        return (RL_FAIL);
-                }
+            cma_free(input);
+            return (RL_CRIT_SUCCES);
         }
-        pf_printf_fd(2, "116-Error: read line memory allocation failed\n");
-        return (-1);
+        else if ((ft_strcmp(input, "succes") == 0)
+            || (ft_strcmp(input, "success") == 0))
+        {
+            cma_free(input);
+            return (RL_SUCCES);
+        }
+        else if ((ft_strcmp(input, "crit fail") == 0)
+            || (ft_strcmp(input, "critical fail") == 0))
+        {
+            cma_free(input);
+            return (RL_CRIT_FAIL);
+        }
+        else if ((ft_strcmp(input, "fail") == 0)
+            || (ft_strcmp(input, "failure") == 0))
+        {
+            cma_free(input);
+            return (RL_FAIL);
+        }
+        cma_free(input);
+    }
+    return (RL_INPUT_CANCEL);
 }
 
 static int ft_check_spell_slots(int spell_level, t_char * character)


### PR DESCRIPTION
## Summary
- treat readline confirm/check helpers returning nullptr as a user cancellation instead of an allocation failure
- propagate the new cancellation status to callers so cleanup commands and spell prompts stop quietly when EOF is sent
- document that prompts can be cancelled with Ctrl+D without triggering an error message

## Testing
- make *(fails: save_data.cpp:36:21: error: ‘const class ft_set<ft_string>’ has no member named ‘data’)*

------
https://chatgpt.com/codex/tasks/task_e_68cd66243a5c8331b92b0cbe20585ebb