### PR TITLE
Use ft_bzero to clear character names

### DIFF
--- a/initialize.cpp
+++ b/initialize.cpp
@@ -3,13 +3,7 @@
 
 void ft_initialize_variables(t_target_data *target_data)
 {
-    int index = 0;
-
     target_data->buff_info = ft_nullptr;
-    while (index < 20)
-    {
-        target_data->Pchar_name[index] = ft_nullptr;
-        index++;
-    }
+    ft_bzero(target_data->Pchar_name, sizeof(target_data->Pchar_name));
     return ;
 }


### PR DESCRIPTION
## Summary
- replace the manual loop in ft_initialize_variables with ft_bzero to clear Pchar_name
- remove the unused index variable now that ft_bzero handles the reset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd93cd9f208331961d08dabe48aab1