### PR TITLE
Fix concentration target cleanup in revert helper

### DIFF
--- a/open.cpp
+++ b/open.cpp
@@ -71,14 +71,16 @@ void    ft_cast_concentration_save_files(t_char * info, t_target_data *target_da
 
 static void    ft_revert_changes_info(t_char * info, ft_file &file)
 {
-    cma_free(info->concentration.targets[0]);
-    cma_free(info->concentration.targets);
-    info->concentration.targets = ft_nullptr;
-       info->concentration.concentration = 0;
-       info->concentration.spell_id = 0;
-       info->concentration.dice_faces_mod = 0;
-       info->concentration.dice_amount_mod = 0;
-       info->concentration.duration = 0;
+    if (info->concentration.targets != ft_nullptr)
+    {
+        cma_free_double(info->concentration.targets);
+        info->concentration.targets = ft_nullptr;
+    }
+    info->concentration.concentration = 0;
+    info->concentration.spell_id = 0;
+    info->concentration.dice_faces_mod = 0;
+    info->concentration.dice_amount_mod = 0;
+    info->concentration.duration = 0;
     ft_npc_write_file(info, &info->stats, &info->c_resistance, file);
     return ;
 }


### PR DESCRIPTION
## Summary
- guard `ft_revert_changes_info` against null concentration target arrays
- free all duplicated concentration targets with `cma_free_double` before resetting state

## Testing
- `make open.o`


------
https://chatgpt.com/codex/tasks/task_e_68cda7522acc8331905b5e65cd7d1665