### PR TITLE
Handle file open failure when removing concentration

### DIFF
--- a/remove_concentration.cpp
+++ b/remove_concentration.cpp
@@ -59,8 +59,11 @@ int ft_remove_concentration(t_char * info)
     buff.target_amount = i;
     targets.buff_info = &buff;
     ft_file info_save_file(ft_check_and_open(&targets, info));
-    if (info_save_file.get_error())
+    if (info_save_file.get_error() || info_save_file.get_fd() == -1)
+    {
+        ft_free_memory_cmt(&targets, i);
         return (FAILURE);
+    }
     ft_concentration_remove_buf(info, &targets);
     ft_cast_concentration_save_files(info, &targets, info_save_file);
     info->flags.alreaddy_saved = 0;


### PR DESCRIPTION
## Summary
- treat a -1 file descriptor from `ft_check_and_open` as a failure when removing concentration
- free any collected concentration targets before returning on failure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cda83eaa8c83319500069e654e529a