### PR TITLE
Fix readline spell level memory handling

### DIFF
--- a/readline_check.cpp
+++ b/readline_check.cpp
@@ -130,9 +130,15 @@ int ft_readline_spell_level(const char *message, t_char * character,
         if (!input)
             return (-1);
         if (ft_strcmp("exit", input) == 0)
+        {
+            cma_free(input);
+            input = ft_nullptr;
             return (-1);
+        }
         if (ft_check_value(input))
         {
+            cma_free(input);
+            input = ft_nullptr;
             pf_printf_fd(2, "Invalid input\n");
             (*invalid_input_amount)++;
             if (*invalid_input_amount >= 5)


### PR DESCRIPTION
## Summary
- release the CMA input buffer when the user types "exit" during spell level prompts to avoid leaking memory
- free and null the input buffer before handling validation errors so repeated prompts do not leak

## Testing
- make tests
- ./automated_tests

------
https://chatgpt.com/codex/tasks/task_e_68cdac7d22b0833192ca354abb202843