### PR TITLE
Refactor resistance calculations

### DIFF
--- a/calculate_damage_reduction.cpp
+++ b/calculate_damage_reduction.cpp
@@ -1,248 +1,94 @@
 #include "dnd_tools.hpp"
 
+static int    ft_calculate_total_dr(t_char * info, int t_resistance::*field)
+{
+    t_equipment_id    *equipment_slots[12];
+    int                index;
+    int                total;
+
+    equipment_slots[0] = &info->equipment.weapon;
+    equipment_slots[1] = &info->equipment.offhand_weapon;
+    equipment_slots[2] = &info->equipment.ranged_weapon;
+    equipment_slots[3] = &info->equipment.armor;
+    equipment_slots[4] = &info->equipment.helmet;
+    equipment_slots[5] = &info->equipment.shield;
+    equipment_slots[6] = &info->equipment.boots;
+    equipment_slots[7] = &info->equipment.gloves;
+    equipment_slots[8] = &info->equipment.amulet;
+    equipment_slots[9] = &info->equipment.ring_01;
+    equipment_slots[10] = &info->equipment.ring_02;
+    equipment_slots[11] = &info->equipment.belt;
+    index = 0;
+    total = 0;
+    while (index < 12)
+    {
+        total += ((equipment_slots[index]->flat_dr).*field);
+        index = index + 1;
+    }
+    return (total);
+}
+
 int    ft_calculate_acid_dr(t_char * info)
 {
-    int acid_dr;
-
-    acid_dr = info->equipment.weapon.flat_dr.acid;
-    acid_dr += info->equipment.offhand_weapon.flat_dr.acid;
-    acid_dr += info->equipment.ranged_weapon.flat_dr.acid;
-    acid_dr += info->equipment.armor.flat_dr.acid;
-    acid_dr += info->equipment.helmet.flat_dr.acid;
-    acid_dr += info->equipment.shield.flat_dr.acid;
-    acid_dr += info->equipment.boots.flat_dr.acid;
-    acid_dr += info->equipment.gloves.flat_dr.acid;
-    acid_dr += info->equipment.amulet.flat_dr.acid;
-    acid_dr += info->equipment.ring_01.flat_dr.acid;
-    acid_dr += info->equipment.ring_02.flat_dr.acid;
-    acid_dr += info->equipment.belt.flat_dr.acid;
-    return (acid_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::acid));
 }
 
 int    ft_calculate_bludgeoning_dr(t_char * info)
 {
-    int bludgeoning_dr;
-
-    bludgeoning_dr = info->equipment.weapon.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.offhand_weapon.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.ranged_weapon.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.armor.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.helmet.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.shield.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.boots.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.gloves.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.amulet.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.ring_01.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.ring_02.flat_dr.bludgeoning;
-    bludgeoning_dr += info->equipment.belt.flat_dr.bludgeoning;
-    return (bludgeoning_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::bludgeoning));
 }
 
 int    ft_calculate_cold_dr(t_char * info)
 {
-    int cold_dr;
-
-    cold_dr = info->equipment.weapon.flat_dr.cold;
-    cold_dr += info->equipment.offhand_weapon.flat_dr.cold;
-    cold_dr += info->equipment.ranged_weapon.flat_dr.cold;
-    cold_dr += info->equipment.armor.flat_dr.cold;
-    cold_dr += info->equipment.helmet.flat_dr.cold;
-    cold_dr += info->equipment.shield.flat_dr.cold;
-    cold_dr += info->equipment.boots.flat_dr.cold;
-    cold_dr += info->equipment.gloves.flat_dr.cold;
-    cold_dr += info->equipment.amulet.flat_dr.cold;
-    cold_dr += info->equipment.ring_01.flat_dr.cold;
-    cold_dr += info->equipment.ring_02.flat_dr.cold;
-    cold_dr += info->equipment.belt.flat_dr.cold;
-    return (cold_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::cold));
 }
 
 int    ft_calculate_fire_dr(t_char * info)
 {
-    int fire_dr;
-
-    fire_dr = info->equipment.weapon.flat_dr.fire;
-    fire_dr += info->equipment.offhand_weapon.flat_dr.fire;
-    fire_dr += info->equipment.ranged_weapon.flat_dr.fire;
-    fire_dr += info->equipment.armor.flat_dr.fire;
-    fire_dr += info->equipment.helmet.flat_dr.fire;
-    fire_dr += info->equipment.shield.flat_dr.fire;
-    fire_dr += info->equipment.boots.flat_dr.fire;
-    fire_dr += info->equipment.gloves.flat_dr.fire;
-    fire_dr += info->equipment.amulet.flat_dr.fire;
-    fire_dr += info->equipment.ring_01.flat_dr.fire;
-    fire_dr += info->equipment.ring_02.flat_dr.fire;
-    fire_dr += info->equipment.belt.flat_dr.fire;
-    return (fire_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::fire));
 }
 
 int    ft_calculate_force_dr(t_char * info)
 {
-    int force_dr;
-
-    force_dr = info->equipment.weapon.flat_dr.force;
-    force_dr += info->equipment.offhand_weapon.flat_dr.force;
-    force_dr += info->equipment.ranged_weapon.flat_dr.force;
-    force_dr += info->equipment.armor.flat_dr.force;
-    force_dr += info->equipment.helmet.flat_dr.force;
-    force_dr += info->equipment.shield.flat_dr.force;
-    force_dr += info->equipment.boots.flat_dr.force;
-    force_dr += info->equipment.gloves.flat_dr.force;
-    force_dr += info->equipment.amulet.flat_dr.force;
-    force_dr += info->equipment.ring_01.flat_dr.force;
-    force_dr += info->equipment.ring_02.flat_dr.force;
-    force_dr += info->equipment.belt.flat_dr.force;
-    return (force_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::force));
 }
 
 int    ft_calculate_lightning_dr(t_char * info)
 {
-    int lightning_dr;
-
-    lightning_dr = info->equipment.weapon.flat_dr.lightning;
-    lightning_dr += info->equipment.offhand_weapon.flat_dr.lightning;
-    lightning_dr += info->equipment.ranged_weapon.flat_dr.lightning;
-    lightning_dr += info->equipment.armor.flat_dr.lightning;
-    lightning_dr += info->equipment.helmet.flat_dr.lightning;
-    lightning_dr += info->equipment.shield.flat_dr.lightning;
-    lightning_dr += info->equipment.boots.flat_dr.lightning;
-    lightning_dr += info->equipment.gloves.flat_dr.lightning;
-    lightning_dr += info->equipment.amulet.flat_dr.lightning;
-    lightning_dr += info->equipment.ring_01.flat_dr.lightning;
-    lightning_dr += info->equipment.ring_02.flat_dr.lightning;
-    lightning_dr += info->equipment.belt.flat_dr.lightning;
-    return (lightning_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::lightning));
 }
 
 int    ft_calculate_necrotic_dr(t_char * info)
 {
-    int necrotic_dr;
-
-    necrotic_dr = info->equipment.weapon.flat_dr.necrotic;
-    necrotic_dr += info->equipment.offhand_weapon.flat_dr.necrotic;
-    necrotic_dr += info->equipment.ranged_weapon.flat_dr.necrotic;
-    necrotic_dr += info->equipment.armor.flat_dr.necrotic;
-    necrotic_dr += info->equipment.helmet.flat_dr.necrotic;
-    necrotic_dr += info->equipment.shield.flat_dr.necrotic;
-    necrotic_dr += info->equipment.boots.flat_dr.necrotic;
-    necrotic_dr += info->equipment.gloves.flat_dr.necrotic;
-    necrotic_dr += info->equipment.amulet.flat_dr.necrotic;
-    necrotic_dr += info->equipment.ring_01.flat_dr.necrotic;
-    necrotic_dr += info->equipment.ring_02.flat_dr.necrotic;
-    necrotic_dr += info->equipment.belt.flat_dr.necrotic;
-    return (necrotic_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::necrotic));
 }
 
 int    ft_calculate_piercing_dr(t_char * info)
 {
-    int piercing_dr;
-
-    piercing_dr = info->equipment.weapon.flat_dr.piercing;
-    piercing_dr += info->equipment.offhand_weapon.flat_dr.piercing;
-    piercing_dr += info->equipment.ranged_weapon.flat_dr.piercing;
-    piercing_dr += info->equipment.armor.flat_dr.piercing;
-    piercing_dr += info->equipment.helmet.flat_dr.piercing;
-    piercing_dr += info->equipment.shield.flat_dr.piercing;
-    piercing_dr += info->equipment.boots.flat_dr.piercing;
-    piercing_dr += info->equipment.gloves.flat_dr.piercing;
-    piercing_dr += info->equipment.amulet.flat_dr.piercing;
-    piercing_dr += info->equipment.ring_01.flat_dr.piercing;
-    piercing_dr += info->equipment.ring_02.flat_dr.piercing;
-    piercing_dr += info->equipment.belt.flat_dr.piercing;
-    return (piercing_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::piercing));
 }
 
 int    ft_calculate_poison_dr(t_char * info)
 {
-    int poison_dr;
-
-    poison_dr = info->equipment.weapon.flat_dr.poison;
-    poison_dr += info->equipment.offhand_weapon.flat_dr.poison;
-    poison_dr += info->equipment.ranged_weapon.flat_dr.poison;
-    poison_dr += info->equipment.armor.flat_dr.poison;
-    poison_dr += info->equipment.helmet.flat_dr.poison;
-    poison_dr += info->equipment.shield.flat_dr.poison;
-    poison_dr += info->equipment.boots.flat_dr.poison;
-    poison_dr += info->equipment.gloves.flat_dr.poison;
-    poison_dr += info->equipment.amulet.flat_dr.poison;
-    poison_dr += info->equipment.ring_01.flat_dr.poison;
-    poison_dr += info->equipment.ring_02.flat_dr.poison;
-    poison_dr += info->equipment.belt.flat_dr.poison;
-    return (poison_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::poison));
 }
 
 int    ft_calculate_psychic_dr(t_char * info)
 {
-    int psychic_dr;
-
-    psychic_dr = info->equipment.weapon.flat_dr.psychic;
-    psychic_dr += info->equipment.offhand_weapon.flat_dr.psychic;
-    psychic_dr += info->equipment.ranged_weapon.flat_dr.psychic;
-    psychic_dr += info->equipment.armor.flat_dr.psychic;
-    psychic_dr += info->equipment.helmet.flat_dr.psychic;
-    psychic_dr += info->equipment.shield.flat_dr.psychic;
-    psychic_dr += info->equipment.boots.flat_dr.psychic;
-    psychic_dr += info->equipment.gloves.flat_dr.psychic;
-    psychic_dr += info->equipment.amulet.flat_dr.psychic;
-    psychic_dr += info->equipment.ring_01.flat_dr.psychic;
-    psychic_dr += info->equipment.ring_02.flat_dr.psychic;
-    psychic_dr += info->equipment.belt.flat_dr.psychic;
-    return (psychic_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::psychic));
 }
 
 int    ft_calculate_radiant_dr(t_char * info)
 {
-    int radiant_dr;
-
-    radiant_dr = info->equipment.weapon.flat_dr.radiant;
-    radiant_dr += info->equipment.offhand_weapon.flat_dr.radiant;
-    radiant_dr += info->equipment.ranged_weapon.flat_dr.radiant;
-    radiant_dr += info->equipment.armor.flat_dr.radiant;
-    radiant_dr += info->equipment.helmet.flat_dr.radiant;
-    radiant_dr += info->equipment.shield.flat_dr.radiant;
-    radiant_dr += info->equipment.boots.flat_dr.radiant;
-    radiant_dr += info->equipment.gloves.flat_dr.radiant;
-    radiant_dr += info->equipment.amulet.flat_dr.radiant;
-    radiant_dr += info->equipment.ring_01.flat_dr.radiant;
-    radiant_dr += info->equipment.ring_02.flat_dr.radiant;
-    radiant_dr += info->equipment.belt.flat_dr.radiant;
-    return (radiant_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::radiant));
 }
 
 int    ft_calculate_slashing_dr(t_char * info)
 {
-    int slashing_dr;
-
-    slashing_dr = info->equipment.weapon.flat_dr.slashing;
-    slashing_dr += info->equipment.offhand_weapon.flat_dr.slashing;
-    slashing_dr += info->equipment.ranged_weapon.flat_dr.slashing;
-    slashing_dr += info->equipment.armor.flat_dr.slashing;
-    slashing_dr += info->equipment.helmet.flat_dr.slashing;
-    slashing_dr += info->equipment.shield.flat_dr.slashing;
-    slashing_dr += info->equipment.boots.flat_dr.slashing;
-    slashing_dr += info->equipment.gloves.flat_dr.slashing;
-    slashing_dr += info->equipment.amulet.flat_dr.slashing;
-    slashing_dr += info->equipment.ring_01.flat_dr.slashing;
-    slashing_dr += info->equipment.ring_02.flat_dr.slashing;
-    slashing_dr += info->equipment.belt.flat_dr.slashing;
-    return (slashing_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::slashing));
 }
 
 int    ft_calculate_thunder_dr(t_char * info)
 {
-    int thunder_dr;
-
-    thunder_dr = info->equipment.weapon.flat_dr.thunder;
-    thunder_dr += info->equipment.offhand_weapon.flat_dr.thunder;
-    thunder_dr += info->equipment.ranged_weapon.flat_dr.thunder;
-    thunder_dr += info->equipment.armor.flat_dr.thunder;
-    thunder_dr += info->equipment.helmet.flat_dr.thunder;
-    thunder_dr += info->equipment.shield.flat_dr.thunder;
-    thunder_dr += info->equipment.boots.flat_dr.thunder;
-    thunder_dr += info->equipment.gloves.flat_dr.thunder;
-    thunder_dr += info->equipment.amulet.flat_dr.thunder;
-    thunder_dr += info->equipment.ring_01.flat_dr.thunder;
-    thunder_dr += info->equipment.ring_02.flat_dr.thunder;
-    thunder_dr += info->equipment.belt.flat_dr.thunder;
-    return (thunder_dr);
+    return (ft_calculate_total_dr(info, &t_resistance::thunder));
 }

--- a/calculate_resistance.cpp
+++ b/calculate_resistance.cpp
@@ -1,261 +1,94 @@
 #include "dnd_tools.hpp"
 
+static int    ft_calculate_total_resistance(t_char * info, int t_resistance::*field)
+{
+    t_equipment_id    *equipment_slots[12];
+    int                index;
+    int                total;
+
+    equipment_slots[0] = &info->equipment.weapon;
+    equipment_slots[1] = &info->equipment.offhand_weapon;
+    equipment_slots[2] = &info->equipment.ranged_weapon;
+    equipment_slots[3] = &info->equipment.armor;
+    equipment_slots[4] = &info->equipment.helmet;
+    equipment_slots[5] = &info->equipment.shield;
+    equipment_slots[6] = &info->equipment.boots;
+    equipment_slots[7] = &info->equipment.gloves;
+    equipment_slots[8] = &info->equipment.amulet;
+    equipment_slots[9] = &info->equipment.ring_01;
+    equipment_slots[10] = &info->equipment.ring_02;
+    equipment_slots[11] = &info->equipment.belt;
+    total = (info->c_resistance).*field;
+    index = 0;
+    while (index < 12)
+    {
+        total += ((equipment_slots[index]->resistance).*field);
+        index = index + 1;
+    }
+    return (total);
+}
+
 int    ft_calculate_acid_resistance(t_char * info)
 {
-    int acid;
-
-    acid = info->c_resistance.acid;
-    acid += info->equipment.weapon.resistance.acid;
-    acid += info->equipment.offhand_weapon.resistance.acid;
-    acid += info->equipment.ranged_weapon.resistance.acid;
-    acid += info->equipment.armor.resistance.acid;
-    acid += info->equipment.helmet.resistance.acid;
-    acid += info->equipment.shield.resistance.acid;
-    acid += info->equipment.boots.resistance.acid;
-    acid += info->equipment.gloves.resistance.acid;
-    acid += info->equipment.amulet.resistance.acid;
-    acid += info->equipment.ring_01.resistance.acid;
-    acid += info->equipment.ring_02.resistance.acid;
-    acid += info->equipment.belt.resistance.acid;
-    return (acid);
+    return (ft_calculate_total_resistance(info, &t_resistance::acid));
 }
 
 int    ft_calculate_bludgeoning_resistance(t_char * info)
 {
-    int bludgeoning;
-
-    bludgeoning = info->c_resistance.bludgeoning;
-    bludgeoning += info->equipment.weapon.resistance.bludgeoning;
-    bludgeoning += info->equipment.offhand_weapon.resistance.bludgeoning;
-    bludgeoning += info->equipment.ranged_weapon.resistance.bludgeoning;
-    bludgeoning += info->equipment.armor.resistance.bludgeoning;
-    bludgeoning += info->equipment.helmet.resistance.bludgeoning;
-    bludgeoning += info->equipment.shield.resistance.bludgeoning;
-    bludgeoning += info->equipment.boots.resistance.bludgeoning;
-    bludgeoning += info->equipment.gloves.resistance.bludgeoning;
-    bludgeoning += info->equipment.amulet.resistance.bludgeoning;
-    bludgeoning += info->equipment.ring_01.resistance.bludgeoning;
-    bludgeoning += info->equipment.ring_02.resistance.bludgeoning;
-    bludgeoning += info->equipment.belt.resistance.bludgeoning;
-    return (bludgeoning);
+    return (ft_calculate_total_resistance(info, &t_resistance::bludgeoning));
 }
 
 int    ft_calculate_cold_resistance(t_char * info)
 {
-    int cold;
-
-    cold = info->c_resistance.cold;
-    cold += info->equipment.weapon.resistance.cold;
-    cold += info->equipment.offhand_weapon.resistance.cold;
-    cold += info->equipment.ranged_weapon.resistance.cold;
-    cold += info->equipment.armor.resistance.cold;
-    cold += info->equipment.helmet.resistance.cold;
-    cold += info->equipment.shield.resistance.cold;
-    cold += info->equipment.boots.resistance.cold;
-    cold += info->equipment.gloves.resistance.cold;
-    cold += info->equipment.amulet.resistance.cold;
-    cold += info->equipment.ring_01.resistance.cold;
-    cold += info->equipment.ring_02.resistance.cold;
-    cold += info->equipment.belt.resistance.cold;
-    return (cold);
+    return (ft_calculate_total_resistance(info, &t_resistance::cold));
 }
 
 int    ft_calculate_fire_resistance(t_char * info)
 {
-    int fire;
-
-    fire = info->c_resistance.fire;
-    fire += info->equipment.weapon.resistance.fire;
-    fire += info->equipment.offhand_weapon.resistance.fire;
-    fire += info->equipment.ranged_weapon.resistance.fire;
-    fire += info->equipment.armor.resistance.fire;
-    fire += info->equipment.helmet.resistance.fire;
-    fire += info->equipment.shield.resistance.fire;
-    fire += info->equipment.boots.resistance.fire;
-    fire += info->equipment.gloves.resistance.fire;
-    fire += info->equipment.amulet.resistance.fire;
-    fire += info->equipment.ring_01.resistance.fire;
-    fire += info->equipment.ring_02.resistance.fire;
-    fire += info->equipment.belt.resistance.fire;
-    return (fire);
+    return (ft_calculate_total_resistance(info, &t_resistance::fire));
 }
 
 int    ft_calculate_force_resistance(t_char * info)
 {
-    int force;
-
-    force = info->c_resistance.force;
-    force += info->equipment.weapon.resistance.force;
-    force += info->equipment.offhand_weapon.resistance.force;
-    force += info->equipment.ranged_weapon.resistance.force;
-    force += info->equipment.armor.resistance.force;
-    force += info->equipment.helmet.resistance.force;
-    force += info->equipment.shield.resistance.force;
-    force += info->equipment.boots.resistance.force;
-    force += info->equipment.gloves.resistance.force;
-    force += info->equipment.amulet.resistance.force;
-    force += info->equipment.ring_01.resistance.force;
-    force += info->equipment.ring_02.resistance.force;
-    force += info->equipment.belt.resistance.force;
-    return (force);
+    return (ft_calculate_total_resistance(info, &t_resistance::force));
 }
 
 int    ft_calculate_lightning_resistance(t_char * info)
 {
-    int lightning;
-
-    lightning = info->c_resistance.lightning;
-    lightning += info->equipment.weapon.resistance.lightning;
-    lightning += info->equipment.offhand_weapon.resistance.lightning;
-    lightning += info->equipment.ranged_weapon.resistance.lightning;
-    lightning += info->equipment.armor.resistance.lightning;
-    lightning += info->equipment.helmet.resistance.lightning;
-    lightning += info->equipment.shield.resistance.lightning;
-    lightning += info->equipment.boots.resistance.lightning;
-    lightning += info->equipment.gloves.resistance.lightning;
-    lightning += info->equipment.amulet.resistance.lightning;
-    lightning += info->equipment.ring_01.resistance.lightning;
-    lightning += info->equipment.ring_02.resistance.lightning;
-    lightning += info->equipment.belt.resistance.lightning;
-    return (lightning);
+    return (ft_calculate_total_resistance(info, &t_resistance::lightning));
 }
 
 int    ft_calculate_necrotic_resistance(t_char * info)
 {
-    int necrotic;
-
-    necrotic = info->c_resistance.necrotic;
-    necrotic += info->equipment.weapon.resistance.necrotic;
-    necrotic += info->equipment.offhand_weapon.resistance.necrotic;
-    necrotic += info->equipment.ranged_weapon.resistance.necrotic;
-    necrotic += info->equipment.armor.resistance.necrotic;
-    necrotic += info->equipment.helmet.resistance.necrotic;
-    necrotic += info->equipment.shield.resistance.necrotic;
-    necrotic += info->equipment.boots.resistance.necrotic;
-    necrotic += info->equipment.gloves.resistance.necrotic;
-    necrotic += info->equipment.amulet.resistance.necrotic;
-    necrotic += info->equipment.ring_01.resistance.necrotic;
-    necrotic += info->equipment.ring_02.resistance.necrotic;
-    necrotic += info->equipment.belt.resistance.necrotic;
-    return (necrotic);
+    return (ft_calculate_total_resistance(info, &t_resistance::necrotic));
 }
 
 int    ft_calculate_piercing_resistance(t_char * info)
 {
-    int piercing;
-
-    piercing = info->c_resistance.piercing;
-    piercing += info->equipment.weapon.resistance.piercing;
-    piercing += info->equipment.offhand_weapon.resistance.piercing;
-    piercing += info->equipment.ranged_weapon.resistance.piercing;
-    piercing += info->equipment.armor.resistance.piercing;
-    piercing += info->equipment.helmet.resistance.piercing;
-    piercing += info->equipment.shield.resistance.piercing;
-    piercing += info->equipment.boots.resistance.piercing;
-    piercing += info->equipment.gloves.resistance.piercing;
-    piercing += info->equipment.amulet.resistance.piercing;
-    piercing += info->equipment.ring_01.resistance.piercing;
-    piercing += info->equipment.ring_02.resistance.piercing;
-    piercing += info->equipment.belt.resistance.piercing;
-    return (piercing);
+    return (ft_calculate_total_resistance(info, &t_resistance::piercing));
 }
 
 int    ft_calculate_poison_resistance(t_char * info)
 {
-    int poison;
-
-    poison = info->c_resistance.poison;
-    poison += info->equipment.weapon.resistance.poison;
-    poison += info->equipment.offhand_weapon.resistance.poison;
-    poison += info->equipment.ranged_weapon.resistance.poison;
-    poison += info->equipment.armor.resistance.poison;
-    poison += info->equipment.helmet.resistance.poison;
-    poison += info->equipment.shield.resistance.poison;
-    poison += info->equipment.boots.resistance.poison;
-    poison += info->equipment.gloves.resistance.poison;
-    poison += info->equipment.amulet.resistance.poison;
-    poison += info->equipment.ring_01.resistance.poison;
-    poison += info->equipment.ring_02.resistance.poison;
-    poison += info->equipment.belt.resistance.poison;
-    return (poison);
+    return (ft_calculate_total_resistance(info, &t_resistance::poison));
 }
 
 int    ft_calculate_psychic_resistance(t_char * info)
 {
-    int psychic;
-
-    psychic = info->c_resistance.psychic;
-    psychic += info->equipment.weapon.resistance.psychic;
-    psychic += info->equipment.offhand_weapon.resistance.psychic;
-    psychic += info->equipment.ranged_weapon.resistance.psychic;
-    psychic += info->equipment.armor.resistance.psychic;
-    psychic += info->equipment.helmet.resistance.psychic;
-    psychic += info->equipment.shield.resistance.psychic;
-    psychic += info->equipment.boots.resistance.psychic;
-    psychic += info->equipment.gloves.resistance.psychic;
-    psychic += info->equipment.amulet.resistance.psychic;
-    psychic += info->equipment.ring_01.resistance.psychic;
-    psychic += info->equipment.ring_02.resistance.psychic;
-    psychic += info->equipment.belt.resistance.psychic;
-    return (psychic);
+    return (ft_calculate_total_resistance(info, &t_resistance::psychic));
 }
 
 int    ft_calculate_radiant_resistance(t_char * info)
 {
-    int radiant;
-
-    radiant = info->c_resistance.radiant;
-    radiant += info->equipment.weapon.resistance.radiant;
-    radiant += info->equipment.offhand_weapon.resistance.radiant;
-    radiant += info->equipment.ranged_weapon.resistance.radiant;
-    radiant += info->equipment.armor.resistance.radiant;
-    radiant += info->equipment.helmet.resistance.radiant;
-    radiant += info->equipment.shield.resistance.radiant;
-    radiant += info->equipment.boots.resistance.radiant;
-    radiant += info->equipment.gloves.resistance.radiant;
-    radiant += info->equipment.amulet.resistance.radiant;
-    radiant += info->equipment.ring_01.resistance.radiant;
-    radiant += info->equipment.ring_02.resistance.radiant;
-    radiant += info->equipment.belt.resistance.radiant;
-    return (radiant);
+    return (ft_calculate_total_resistance(info, &t_resistance::radiant));
 }
 
 int    ft_calculate_slashing_resistance(t_char * info)
 {
-    int slashing;
-
-    slashing = info->c_resistance.slashing;
-    slashing += info->equipment.weapon.resistance.slashing;
-    slashing += info->equipment.offhand_weapon.resistance.slashing;
-    slashing += info->equipment.ranged_weapon.resistance.slashing;
-    slashing += info->equipment.armor.resistance.slashing;
-    slashing += info->equipment.helmet.resistance.slashing;
-    slashing += info->equipment.shield.resistance.slashing;
-    slashing += info->equipment.boots.resistance.slashing;
-    slashing += info->equipment.gloves.resistance.slashing;
-    slashing += info->equipment.amulet.resistance.slashing;
-    slashing += info->equipment.ring_01.resistance.slashing;
-    slashing += info->equipment.ring_02.resistance.slashing;
-    slashing += info->equipment.belt.resistance.slashing;
-    return (slashing);
+    return (ft_calculate_total_resistance(info, &t_resistance::slashing));
 }
 
 int    ft_calculate_thunder_resistance(t_char * info)
 {
-    int thunder;
-
-    thunder = info->c_resistance.thunder;
-    thunder += info->equipment.weapon.resistance.thunder;
-    thunder += info->equipment.offhand_weapon.resistance.thunder;
-    thunder += info->equipment.ranged_weapon.resistance.thunder;
-    thunder += info->equipment.armor.resistance.thunder;
-    thunder += info->equipment.helmet.resistance.thunder;
-    thunder += info->equipment.shield.resistance.thunder;
-    thunder += info->equipment.boots.resistance.thunder;
-    thunder += info->equipment.gloves.resistance.thunder;
-    thunder += info->equipment.amulet.resistance.thunder;
-    thunder += info->equipment.ring_01.resistance.thunder;
-    thunder += info->equipment.ring_02.resistance.thunder;
-    thunder += info->equipment.belt.resistance.thunder;
-    return (thunder);
+    return (ft_calculate_total_resistance(info, &t_resistance::thunder));
 }


### PR DESCRIPTION
## Summary
- add helper in `calculate_damage_reduction.cpp` to accumulate flat damage reduction values via a pointer-to-member and reuse it for each damage type wrapper
- add helper in `calculate_resistance.cpp` to sum character and equipment resistances via a pointer-to-member and simplify every resistance wrapper

## Testing
- make

------
https://chatgpt.com/codex/tasks/task_e_68cdb13346ac8331911597fe99523783