### PR TITLE
Refactor NPC skill roll lookup

### DIFF
--- a/npc_change_stats_02.cpp
+++ b/npc_change_stats_02.cpp
@@ -1,52 +1,56 @@
 #include "dnd_tools.hpp"
 #include "libft/Printf/printf.hpp"
 
+typedef int (*t_skill_calc)(t_char * info);
+
+typedef struct s_skill_table_entry
+{
+    const char  *name;
+    t_skill_calc ability;
+    t_skill_calc skill;
+}   t_skill_table_entry;
+
+static const t_skill_table_entry g_skill_table[] = {
+    {"athletics", &ft_calculate_str, &ft_calculate_athletics},
+    {"acrobatics", &ft_calculate_dex, &ft_calculate_acrobatics},
+    {"sleight_of_hand", &ft_calculate_dex, &ft_calculate_sleight_of_hand},
+    {"stealth", &ft_calculate_dex, &ft_calculate_stealth},
+    {"arcana", &ft_calculate_inte, &ft_calculate_arcana},
+    {"history", &ft_calculate_inte, &ft_calculate_history},
+    {"investigation", &ft_calculate_inte, &ft_calculate_investigation},
+    {"nature", &ft_calculate_inte, &ft_calculate_nature},
+    {"religion", &ft_calculate_inte, &ft_calculate_religion},
+    {"animal_handling", &ft_calculate_wis, &ft_calculate_animal_handling},
+    {"insight", &ft_calculate_wis, &ft_calculate_insight},
+    {"medicine", &ft_calculate_wis, &ft_calculate_medicine},
+    {"perception", &ft_calculate_wis, &ft_calculate_perception},
+    {"survival", &ft_calculate_wis, &ft_calculate_survival},
+    {"deception", &ft_calculate_cha, &ft_calculate_deception},
+    {"intimidation", &ft_calculate_cha, &ft_calculate_intimidation},
+    {"performance", &ft_calculate_cha, &ft_calculate_performance},
+    {"persuasion", &ft_calculate_cha, &ft_calculate_persuasion}
+};
+
+static const int g_skill_table_size = 18;
+
 static int    ft_skill_roll(t_char * info, const char **input)
 {
-    if (ft_strcmp(input[1], "athletics") == 0)
-        ft_skill_throw(info, "athletics", ft_calculate_str(info), ft_calculate_athletics(info));
-    else if (ft_strcmp(input[1], "acrobatics") == 0)
-        ft_skill_throw(info, "acrobatics", ft_calculate_dex(info), ft_calculate_acrobatics(info));
-    else if (ft_strcmp(input[1], "sleight_of_hand") == 0)
-        ft_skill_throw(info, "sleight_of_hand", ft_calculate_dex(info),
-                ft_calculate_sleight_of_hand(info));
-    else if (ft_strcmp(input[1], "stealth") == 0)
-        ft_skill_throw(info, "stealth", ft_calculate_dex(info), ft_calculate_stealth(info));
-    else if (ft_strcmp(input[1], "arcana") == 0)
-        ft_skill_throw(info, "arcana", ft_calculate_inte(info), ft_calculate_arcana(info));
-    else if (ft_strcmp(input[1], "history") == 0)
-        ft_skill_throw(info, "history", ft_calculate_inte(info), ft_calculate_history(info));
-    else if (ft_strcmp(input[1], "investigation") == 0)
-        ft_skill_throw(info, "investigation", ft_calculate_inte(info),
-                ft_calculate_investigation(info));
-    else if (ft_strcmp(input[1], "nature") == 0)
-        ft_skill_throw(info, "nature", ft_calculate_inte(info), ft_calculate_nature(info));
-    else if (ft_strcmp(input[1], "religion") == 0)
-        ft_skill_throw(info, "religion", ft_calculate_inte(info), ft_calculate_religion(info));
-    else if (ft_strcmp(input[1], "animal_handling") == 0)
-        ft_skill_throw(info, "animal_handling", ft_calculate_wis(info),
-                ft_calculate_animal_handling(info));
-    else if (ft_strcmp(input[1], "insight") == 0)
-        ft_skill_throw(info, "insight", ft_calculate_wis(info), ft_calculate_insight(info));
-    else if (ft_strcmp(input[1], "medicine") == 0)
-        ft_skill_throw(info, "medicine", ft_calculate_wis(info), ft_calculate_medicine(info));
-    else if (ft_strcmp(input[1], "perception") == 0)
-        ft_skill_throw(info, "perception", ft_calculate_wis(info), ft_calculate_perception(info));
-    else if (ft_strcmp(input[1], "survival") == 0)
-        ft_skill_throw(info, "survival", ft_calculate_wis(info), ft_calculate_survival(info));
-    else if (ft_strcmp(input[1], "deception") == 0)
-        ft_skill_throw(info, "deception", ft_calculate_cha(info), ft_calculate_deception(info));
-    else if (ft_strcmp(input[1], "intimidation") == 0)
-        ft_skill_throw(info, "intimidation", ft_calculate_cha(info),
-                ft_calculate_intimidation(info));
-    else if (ft_strcmp(input[1], "performance") == 0)
-        ft_skill_throw(info, "performance", ft_calculate_cha(info), ft_calculate_performance(info));
-    else if (ft_strcmp(input[1], "persuasion") == 0)
-        ft_skill_throw(info, "persuasion", ft_calculate_cha(info), ft_calculate_persuasion(info));
-    else
-        return (1);
-    return (0);
-}    
+    int index;
+
+    index = 0;
+    while (index < g_skill_table_size)
+    {
+        if (ft_strcmp(input[1], g_skill_table[index].name) == 0)
+        {
+            ft_skill_throw(info, g_skill_table[index].name,
+                g_skill_table[index].ability(info),
+                g_skill_table[index].skill(info));
+            return (0);
+        }
+        index++;
+    }
+    return (1);
+}
 
 void    ft_npc_sstuff(t_char * info, const char **input)
 {


### PR DESCRIPTION
## Summary
- add a static lookup table that pairs each skill with its ability and skill calculators
- update ft_skill_roll to search the table with libft helpers and call ft_skill_throw through stored pointers

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68cdb928d81c8331a3aeed2a50bba25d