### PR TITLE
Ensure initiative additions append missing entry

### DIFF
--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -165,7 +165,7 @@ void ft_initiative_add(t_char * info)
         pf_printf_fd(initiative_file, "%s\n", content[i]);
         i++;
     }
-    if (!content && !added)
+    if (added == 0)
     {
         pf_printf_fd(initiative_file, "%s=%d\n", info->name, info->initiative);
         added = 1;


### PR DESCRIPTION
## Summary
- ensure `ft_initiative_add` appends a new initiative entry if the main loop never inserts it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdca49832c833196d88c3b4e301949