### PR TITLE
Fix Divine Smite upcast damage and add tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,8 @@ SRC         = name.cpp \
               npc_set_stats_player.cpp \
               crackback.cpp \
               frank.cpp \
-			  cast_divine_smite.cpp \
+                          cast_divine_smite.cpp \
+                          divine_smite_utils.cpp \
 			  cast_cure_wounds.cpp \
               cast_lightning_bolt.cpp \
 			  spell_utils.cpp \
@@ -267,9 +268,11 @@ TEST_SRC    = tests/automated_tests.cpp \
              tests/calculate_stats_tests.cpp \
              tests/calculate_skills_tests.cpp \
              tests/calculate_util_stats_tests.cpp \
+             tests/divine_smite_tests.cpp \
              tests/create_data_folder_tests.cpp \
               tests/save_load_test_stubs.cpp \
               tests/save_load_tests.cpp \
+             divine_smite_utils.cpp \
               trim_start.cpp \
               ordinal_suffix.cpp \
               roll.cpp \

--- a/cast_divine_smite.cpp
+++ b/cast_divine_smite.cpp
@@ -15,24 +15,15 @@ static int ft_check_divine_smite_learned(t_char * character)
 
 void ft_cast_divine_smite(t_char * character, bool critical_strike)
 {
-    int multiplyer = 1;
-    if (critical_strike)
-        multiplyer = 2;
     if (!ft_check_divine_smite_learned(character))
         return ;
     int base_level = character->spells.divine_smite.base_level;
-        int cast_at_level = ft_prompt_spell_level(character, base_level, "Divine Smite");
+    int cast_at_level = ft_prompt_spell_level(character, base_level, "Divine Smite");
     if (cast_at_level == -1)
         return ;
     t_spell_divine_smite *divine_smite = &character->spells.divine_smite;
-    int upcast_level = base_level - cast_at_level;
-    int total_dice = (divine_smite->dice_amount + (divine_smite->upcast_extra_dice_amount
-            * upcast_level)) * multiplyer;
-    int dice_faces = divine_smite->dice_faces
-                    + (divine_smite->upcast_extra_dice_face * upcast_level);
-    int extra_damage = divine_smite->extra_damage
-                    + (divine_smite->upcast_extra_damage * upcast_level);
-    int damage = ft_calculate_spell_damage(total_dice, dice_faces, extra_damage);
+    int damage = ft_divine_smite_damage_roll(divine_smite, cast_at_level,
+            critical_strike);
     if (damage == -1)
     {
         pf_printf_fd(2, "Error: Failed to calculate damage for Divine Smite.\n");

--- a/divine_smite_utils.cpp
+++ b/divine_smite_utils.cpp
@@ -1,0 +1,33 @@
+#include "character.hpp"
+#include "dnd_tools.hpp"
+#include "libft/Printf/printf.hpp"
+#include "libft/RNG/rng.hpp"
+
+int ft_divine_smite_damage_roll(t_spell_divine_smite *divine_smite,
+        int cast_at_level, bool critical_strike)
+{
+    int multiplyer = 1;
+    int upcast_level = cast_at_level - divine_smite->base_level;
+    int total_dice;
+    int dice_faces;
+    int extra_damage;
+    int dice_roll_result;
+
+    if (critical_strike)
+        multiplyer = 2;
+    if (upcast_level < 0)
+        upcast_level = 0;
+    total_dice = (divine_smite->dice_amount
+            + (divine_smite->upcast_extra_dice_amount * upcast_level)) * multiplyer;
+    dice_faces = divine_smite->dice_faces
+                    + (divine_smite->upcast_extra_dice_face * upcast_level);
+    extra_damage = divine_smite->extra_damage
+                    + (divine_smite->upcast_extra_damage * upcast_level);
+    dice_roll_result = ft_dice_roll(total_dice, dice_faces);
+    if (dice_roll_result == -1)
+    {
+        pf_printf_fd(2, "Error: Dice roll failed.\n");
+        return (-1);
+    }
+    return (dice_roll_result + extra_damage);
+}

--- a/dnd_tools.hpp
+++ b/dnd_tools.hpp
@@ -250,6 +250,8 @@ int         ft_attack_roll_check_buffs(t_char * info, int *roll);
 void        ft_to_hit_check_buff(t_char * info);
 
 // Cast spell
+int         ft_divine_smite_damage_roll(t_spell_divine_smite *divine_smite,
+                int cast_at_level, bool critical_strike);
 void        ft_cast_divine_smite(t_char * character, bool critical_strike);
 void        ft_cast_cure_wounds(t_char * character);
 void        ft_cast_lightning_bolt(t_char * character);

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -16,6 +16,7 @@ int main()
     run_calculate_stats_tests();
     run_calculate_skills_tests();
     run_calculate_util_stats_tests();
+    run_divine_smite_tests();
     std::printf("All tests passed.\n");
     return (0);
 }

--- a/tests/divine_smite_tests.cpp
+++ b/tests/divine_smite_tests.cpp
@@ -1,0 +1,90 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+
+static void test_divine_smite_upcast_adds_extra_dice()
+{
+    t_spell_divine_smite divine_smite;
+    int base_damage;
+    int upcast_damage;
+
+    divine_smite.learned = 1;
+    divine_smite.base_level = 1;
+    divine_smite.casting_at_level = 0;
+    divine_smite.dice_amount = 2;
+    divine_smite.dice_faces = 1;
+    divine_smite.extra_damage = 0;
+    divine_smite.upcast_extra_dice_face = 0;
+    divine_smite.upcast_extra_dice_amount = 1;
+    divine_smite.upcast_extra_damage = 0;
+
+    base_damage = ft_divine_smite_damage_roll(&divine_smite, 1, false);
+    upcast_damage = ft_divine_smite_damage_roll(&divine_smite, 2, false);
+    test_assert_true(base_damage == 2,
+            "Base damage should equal the number of dice when faces are one");
+    test_assert_true(upcast_damage == 3,
+            "Upcast damage should add one die when cast above base level");
+    test_assert_true(upcast_damage > base_damage,
+            "Upcast damage should be greater than base damage");
+    return ;
+}
+
+static void test_divine_smite_critical_upcast_doubles_dice()
+{
+    t_spell_divine_smite divine_smite;
+    int normal_damage;
+    int critical_damage;
+
+    divine_smite.learned = 1;
+    divine_smite.base_level = 1;
+    divine_smite.casting_at_level = 0;
+    divine_smite.dice_amount = 2;
+    divine_smite.dice_faces = 1;
+    divine_smite.extra_damage = 1;
+    divine_smite.upcast_extra_dice_face = 0;
+    divine_smite.upcast_extra_dice_amount = 1;
+    divine_smite.upcast_extra_damage = 2;
+
+    normal_damage = ft_divine_smite_damage_roll(&divine_smite, 3, false);
+    critical_damage = ft_divine_smite_damage_roll(&divine_smite, 3, true);
+    test_assert_true(normal_damage == 9,
+            "Casting two levels above base should add upcast bonuses before critical");
+    test_assert_true(critical_damage == 13,
+            "Critical upcast should double dice while keeping extra damage additions");
+    test_assert_true(critical_damage > normal_damage,
+            "Critical damage should exceed non-critical damage for the same cast level");
+    return ;
+}
+
+static void test_divine_smite_does_not_reduce_damage_when_cast_lower()
+{
+    t_spell_divine_smite divine_smite;
+    int base_damage;
+    int lower_level_damage;
+
+    divine_smite.learned = 1;
+    divine_smite.base_level = 3;
+    divine_smite.casting_at_level = 0;
+    divine_smite.dice_amount = 2;
+    divine_smite.dice_faces = 1;
+    divine_smite.extra_damage = 0;
+    divine_smite.upcast_extra_dice_face = 5;
+    divine_smite.upcast_extra_dice_amount = 7;
+    divine_smite.upcast_extra_damage = 11;
+
+    base_damage = ft_divine_smite_damage_roll(&divine_smite, 3, false);
+    lower_level_damage = ft_divine_smite_damage_roll(&divine_smite, 1, false);
+    test_assert_true(base_damage == 2,
+            "Base damage should remain unchanged when no upcast is applied");
+    test_assert_true(lower_level_damage == base_damage,
+            "Casting below the base level should not apply negative upcast bonuses");
+    return ;
+}
+
+void run_divine_smite_tests()
+{
+    test_divine_smite_upcast_adds_extra_dice();
+    test_divine_smite_critical_upcast_doubles_dice();
+    test_divine_smite_does_not_reduce_damage_when_cast_lower();
+    return ;
+}

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -11,5 +11,6 @@ void    run_resistance_tests();
 void    run_calculate_stats_tests();
 void    run_calculate_skills_tests();
 void    run_calculate_util_stats_tests();
+void    run_divine_smite_tests();
 
 #endif


### PR DESCRIPTION
## Summary
- ensure Divine Smite upcast bonuses are based on cast level above the base level and clamp the difference before applying extras
- extract the Divine Smite damage roll logic for reuse and reuse it in spell casting
- add deterministic unit tests covering upcast and critical Divine Smite damage calculations

## Testing
- `make tests COMPILE_FLAGS="-Wall -Werror -Wextra -std=c++17 -Wmissing-declarations -Wold-style-cast -Wshadow -Wconversion -Wformat=2 -Wundef -Wfloat-equal -Wconversion -Wodr -Wuseless-cast -Wzero-as-null-pointer-constant -Wmaybe-uninitialized -Wno-error=float-equal"`
- `./automated_tests`


------
https://chatgpt.com/codex/tasks/task_e_68cef7f97a64833191f16644bcbe8ec3