### PR TITLE
Fix auto-cast slot selection and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,6 +269,7 @@ TEST_SRC    = tests/automated_tests.cpp \
              tests/calculate_skills_tests.cpp \
              tests/calculate_util_stats_tests.cpp \
              tests/divine_smite_tests.cpp \
+             tests/spell_utils_tests.cpp \
              tests/create_data_folder_tests.cpp \
               tests/save_load_test_stubs.cpp \
               tests/save_load_tests.cpp \

--- a/spell_utils.cpp
+++ b/spell_utils.cpp
@@ -5,26 +5,44 @@
 #include "libft/Printf/printf.hpp"
 #include <cassert>
 
+static t_spell_slot *ft_get_spell_slot(t_char *character, int level)
+{
+    if (level == 1)
+        return (&character->spell_slots.level_1);
+    else if (level == 2)
+        return (&character->spell_slots.level_2);
+    else if (level == 3)
+        return (&character->spell_slots.level_3);
+    else if (level == 4)
+        return (&character->spell_slots.level_4);
+    else if (level == 5)
+        return (&character->spell_slots.level_5);
+    else if (level == 6)
+        return (&character->spell_slots.level_6);
+    else if (level == 7)
+        return (&character->spell_slots.level_7);
+    else if (level == 8)
+        return (&character->spell_slots.level_8);
+    else if (level == 9)
+        return (&character->spell_slots.level_9);
+    return (0);
+}
+
 static int ft_auto_cast(t_char *character, int base_level, const char *spell_name)
 {
-    if (character->spell_slots.level_1.available > 0 && base_level >= 1)
-        return (1);
-    if (character->spell_slots.level_2.available > 0 && base_level >= 2)
-        return (2);
-    if (character->spell_slots.level_3.available > 0 && base_level >= 3)
-        return (3);
-    if (character->spell_slots.level_4.available > 0 && base_level >= 4)
-        return (4);
-    if (character->spell_slots.level_5.available > 0 && base_level >= 5)
-        return (5);
-    if (character->spell_slots.level_6.available > 0 && base_level >= 6)
-        return (6);
-    if (character->spell_slots.level_7.available > 0 && base_level >= 7)
-        return (7);
-    if (character->spell_slots.level_8.available > 0 && base_level >= 8)
-        return (8);
-    if (character->spell_slots.level_9.available > 0 && base_level >= 9)
-        return (9);
+    int current_level;
+    t_spell_slot *spell_slot;
+
+    current_level = base_level;
+    if (current_level < 1)
+        current_level = 1;
+    while (current_level <= 9)
+    {
+        spell_slot = ft_get_spell_slot(character, current_level);
+        if (spell_slot != 0 && spell_slot->available > 0)
+            return (current_level);
+        current_level++;
+    }
     pf_printf_fd(2, "Error: No available spell slots for %s to cast %s.\n",
             character->name, spell_name);
     return (-1);

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -17,6 +17,7 @@ int main()
     run_calculate_skills_tests();
     run_calculate_util_stats_tests();
     run_divine_smite_tests();
+    run_spell_utils_tests();
     std::printf("All tests passed.\n");
     return (0);
 }

--- a/tests/spell_utils_tests.cpp
+++ b/tests/spell_utils_tests.cpp
@@ -1,0 +1,65 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include "../character.hpp"
+#include <cstring>
+
+static void initialize_character(t_char *character, const char *name)
+{
+    std::memset(character, 0, sizeof(t_char));
+    character->name = name;
+    return ;
+}
+
+static void test_auto_cast_uses_exact_level_when_available()
+{
+    t_char character;
+    int cast_level;
+
+    initialize_character(&character, "Tester");
+    character.spell_slots.level_3.available = 1;
+    g_dnd_test = true;
+    cast_level = ft_prompt_spell_level(&character, 3, "Guiding Bolt");
+    g_dnd_test = false;
+    test_assert_true(cast_level == 3,
+            "Auto cast should use an available slot matching the base level");
+    return ;
+}
+
+static void test_auto_cast_selects_next_highest_slot()
+{
+    t_char character;
+    int cast_level;
+
+    initialize_character(&character, "Tester");
+    character.spell_slots.level_4.available = 2;
+    g_dnd_test = true;
+    cast_level = ft_prompt_spell_level(&character, 3, "Shatter");
+    g_dnd_test = false;
+    test_assert_true(cast_level == 4,
+            "Auto cast should pick the lowest slot at or above the base level");
+    return ;
+}
+
+static void test_auto_cast_reports_error_when_no_valid_slot()
+{
+    t_char character;
+    int cast_level;
+
+    initialize_character(&character, "Tester");
+    character.spell_slots.level_4.available = 1;
+    g_dnd_test = true;
+    cast_level = ft_prompt_spell_level(&character, 5, "Wall of Light");
+    g_dnd_test = false;
+    test_assert_true(cast_level == -1,
+            "Auto cast should fail when no slots meet the required level");
+    return ;
+}
+
+void run_spell_utils_tests()
+{
+    test_auto_cast_uses_exact_level_when_available();
+    test_auto_cast_selects_next_highest_slot();
+    test_auto_cast_reports_error_when_no_valid_slot();
+    return ;
+}

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -12,5 +12,6 @@ void    run_calculate_stats_tests();
 void    run_calculate_skills_tests();
 void    run_calculate_util_stats_tests();
 void    run_divine_smite_tests();
+void    run_spell_utils_tests();
 
 #endif


### PR DESCRIPTION
## Summary
- update `ft_auto_cast` to scan from the requested base level upward and keep existing error reporting
- add spell utility tests that exercise automated casting with `g_dnd_test` enabled and verify slot choice
- register the new test group with the automated test harness and build system

## Testing
- `make test` *(fails: libft/Math/math_fmod.cpp uses floating-point equality; -Wfloat-equal is treated as an error)*

------
https://chatgpt.com/codex/tasks/task_e_68cefbf336008331bb01325f6e0bc846