### PR TITLE
Fix Magic Drain concentration target cleanup order

### DIFF
--- a/cast_magic_drain.cpp
+++ b/cast_magic_drain.cpp
@@ -144,7 +144,10 @@ void    ft_concentration_remove_magic_drain(t_char *character, t_target_data *ta
     character->concentration.dice_amount_mod = 0;
     character->concentration.dice_faces_mod = 0;
     character->concentration.base_mod = 0;
+    char    **targets;
+
+    targets = character->concentration.targets;
+    cma_free_double(targets);
     character->concentration.targets = ft_nullptr;
-    cma_free_double(character->concentration.targets);
     return ;
 }


### PR DESCRIPTION
## Summary
- ensure Magic Drain concentration cleanup frees the original targets array before nulling the pointer

## Testing
- make test *(fails: libft/Math/math_fmod.cpp hits -Wfloat-equal due to upstream code)*

------
https://chatgpt.com/codex/tasks/task_e_68cefe4cd0788331b245601d4311a642