### PR TITLE
Fix concentration rollback uses caster file

### DIFF
--- a/cast_concentration.cpp
+++ b/cast_concentration.cpp
@@ -97,7 +97,7 @@ static int ft_cast_concentration_open_file(ft_file save_files[2], t_char *info,
         info->concentration.dice_faces_mod = 0;
         info->concentration.dice_amount_mod = 0;
         info->concentration.duration = 0;
-        ft_npc_write_file(info, &info->stats, &info->c_resistance, save_files[1]);
+        ft_npc_write_file(info, &info->stats, &info->c_resistance, save_files[0]);
         return (1);
     }
     return (0);


### PR DESCRIPTION
## Summary
- ensure the concentration rollback when the target file cannot be opened writes the caster's save data back to its own file descriptor

## Testing
- make test CFLAGS+=" -Wno-error=float-equal"
- ./automated_tests

------
https://chatgpt.com/codex/tasks/task_e_68ceffa2650c8331b1b580cadc34fbd8