### PR TITLE
Allow two-token player list command

### DIFF
--- a/read_line.cpp
+++ b/read_line.cpp
@@ -68,10 +68,10 @@ static int ft_handle_builtins(char **input, int i, t_name *name, char *input_str
         ft_test(name);
     else if (i == 1 && ft_strcmp(input[0], "help") == 0)
         ft_print_help();
-        else if (i == 3 && ft_strcmp(input[1], "player") == 0)
+    else if (i >= 2 && ft_strcmp(input[1], "player") == 0)
         ft_player(const_cast<const char **>(input));
-        else if (i >= 2 && ft_strcmp(input[0], "encounter") == 0)
-                ft_encounter(i - 1, const_cast<const char **>(input + 1), name);
+    else if (i >= 2 && ft_strcmp(input[0], "encounter") == 0)
+        ft_encounter(i - 1, const_cast<const char **>(input + 1), name);
     else
         return (0);
     return (1);


### PR DESCRIPTION
## Summary
- allow the built-in player command to match when only two tokens are provided so `list player` works
- tidy the adjacent encounter branch indentation for readability

## Testing
- make tests
- ./automated_tests *(fails: ft_create_data_dir reports missing/invalid data directory path)*

------
https://chatgpt.com/codex/tasks/task_e_68deb69975fc83318c3b6e1d8e08a55a