### PR TITLE
Protect PC save directories during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,7 @@ TEST_SRC    = tests/automated_tests.cpp \
              tests/roll_command_argument_tests.cpp \
              tests/roll_command_expression_tests.cpp \
              tests/roll_command_error_tests.cpp \
+             tests/clean_tests.cpp \
              tests/resistance_tests.cpp \
              tests/calculate_stats_tests.cpp \
              tests/calculate_skills_tests.cpp \
@@ -274,6 +275,7 @@ TEST_SRC    = tests/automated_tests.cpp \
              tests/divine_smite_tests.cpp \
              spell_utils.cpp \
              readline_check.cpp \
+             fclean.cpp \
              tests/spell_utils_tests.cpp \
              tests/create_data_folder_tests.cpp \
               tests/save_load_test_stubs.cpp \

--- a/fclean.cpp
+++ b/fclean.cpp
@@ -97,7 +97,7 @@ void ft_clean(void)
     command[0] = "/bin/sh";
     command[1] = "-c";
     command[2] = "find ./data -mindepth 1 -maxdepth 1 \\( ! -name 'data--*' !" \
-                                  "-name 'pc--*' \\) -exec rm -rf {} +";
+                                  " -iname 'pc--*' \\) -exec rm -rf {} +";
     command[3] = ft_nullptr;
     if (g_dnd_test == 0)
     {
@@ -150,7 +150,8 @@ void ft_clean(void)
     for (const auto &entry : std::filesystem::directory_iterator("./data", ec))
     {
         std::string name = entry.path().filename().string();
-        if (name.rfind("data--", 0) == 0 || name.rfind("pc--", 0) == 0)
+        if (name.rfind("data--", 0) == 0 || name.rfind("pc--", 0) == 0
+            || name.rfind("PC--", 0) == 0)
             continue;
         std::filesystem::remove_all(entry, ec);
         if (ec)

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -11,6 +11,7 @@ int main()
     run_roll_validation_tests();
     run_roll_command_tests();
     run_create_data_folder_tests();
+    run_clean_tests();
     run_save_load_tests();
     run_resistance_tests();
     run_calculate_stats_tests();

--- a/tests/clean_tests.cpp
+++ b/tests/clean_tests.cpp
@@ -1,0 +1,52 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include <filesystem>
+#include <system_error>
+#include <cstdio>
+
+static void remove_data_path()
+{
+    std::error_code remove_error;
+
+    std::filesystem::remove_all("data", remove_error);
+    if (remove_error.value() != 0)
+        std::remove("data");
+    return ;
+}
+
+static void test_ft_clean_preserves_player_directory()
+{
+    std::error_code error;
+    bool            exists_result;
+
+    remove_data_path();
+    std::filesystem::create_directories("data/PC--Example", error);
+    test_assert_true(error.value() == 0, "failed to create player directory for test");
+    error.clear();
+    std::filesystem::create_directory("data/temp_dir", error);
+    test_assert_true(error.value() == 0, "failed to create temporary directory for test");
+    g_dnd_test = true;
+    ft_clean();
+    g_dnd_test = false;
+    error.clear();
+    exists_result = std::filesystem::exists("data/PC--Example", error);
+    test_assert_true(error.value() == 0, "failed to check player directory existence");
+    test_assert_true(exists_result == true, "ft_clean should preserve PC-- directories");
+    error.clear();
+    exists_result = std::filesystem::exists("data/temp_dir", error);
+    test_assert_true(error.value() == 0, "failed to check temporary directory existence");
+    test_assert_true(exists_result == false, "ft_clean should remove non-protected directories");
+    remove_data_path();
+    error.clear();
+    std::filesystem::create_directory("data", error);
+    test_assert_true(error.value() == 0, "failed to restore data directory after test");
+    return ;
+}
+
+void run_clean_tests()
+{
+    test_ft_clean_preserves_player_directory();
+    return ;
+}
+

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -8,6 +8,7 @@ void    run_roll_command_tests();
 void    run_roll_command_argument_tests();
 void    run_roll_command_expression_tests();
 void    run_roll_command_error_tests();
+void    run_clean_tests();
 void    run_create_data_folder_tests();
 void    run_save_load_tests();
 void    run_resistance_tests();


### PR DESCRIPTION
## Summary
- adjust the POSIX clean command and Windows guard to keep PC-- save folders intact
- add a regression test that asserts ft_clean preserves player directories while removing other entries
- wire the new test into the automated test suite and build configuration

## Testing
- make automated_tests

------
https://chatgpt.com/codex/tasks/task_e_68debacd048483319d7afb41571018d0