### PR TITLE
Fix data directory creation check

### DIFF
--- a/create_data_folder.cpp
+++ b/create_data_folder.cpp
@@ -21,7 +21,7 @@ int ft_create_data_dir()
             ft_strerror(ft_errno));
         return (1);
     }
-    if (directory_status == 1)
+    if (directory_status == 0)
     {
         if (file_exists("data") == 1)
         {

--- a/npc_set_stats.cpp
+++ b/npc_set_stats.cpp
@@ -36,8 +36,15 @@ static int ft_handle_int_mapping(char **content, int index, t_char * info)
     }
     else if (return_value->_return_field_string)
     {
-        ft_set_stat_player(return_value->_key_length,
+        int player_stat_status;
+
+        player_stat_status = ft_set_stat_player(return_value->_key_length,
                 const_cast<const char **>(return_value->_return_field_string), content[index]);
+        if (player_stat_status != 0)
+        {
+            info->flags.error = 1;
+            return (1);
+        }
         return (0);
     }
     return (1);

--- a/tests/create_data_folder_tests.cpp
+++ b/tests/create_data_folder_tests.cpp
@@ -28,7 +28,7 @@ static void test_create_data_dir_creates_directory_when_missing()
     remove_data_path();
     result = ft_create_data_dir();
     test_assert_true(result == 0, "ft_create_data_dir should create missing data directory");
-    test_assert_true(file_dir_exists("data") == 0, "ft_create_data_dir did not create the data directory");
+    test_assert_true(file_dir_exists("data") == 1, "ft_create_data_dir did not create the data directory");
     test_assert_true(ft_errno == ER_SUCCESS, "ft_create_data_dir should set errno to success after creating directory");
     remove_data_path();
     return ;

--- a/tests/save_load_test_stubs.cpp
+++ b/tests/save_load_test_stubs.cpp
@@ -1,8 +1,10 @@
 #include "../dnd_tools.hpp"
+#include <cstring>
 
 int ft_check_player_entry(const char *entry)
 {
-    (void)entry;
+    if (entry && std::strcmp(entry, "INVALID_PLAYER_ENTRY") == 0)
+        return (1);
     return (0);
 }
 

--- a/tests/save_load_tests.cpp
+++ b/tests/save_load_tests.cpp
@@ -141,6 +141,27 @@ static void cleanup_loaded_npc(t_char &npc)
     return ;
 }
 
+static void test_npc_set_stats_player_entry_failure_sets_error()
+{
+    t_char npc = {};
+    char *content[2];
+    int parse_error;
+
+    npc.name = const_cast<char *>("Test NPC");
+    content[0] = const_cast<char *>("SPELL_MAGIC_DRAIN=INVALID_PLAYER_ENTRY");
+    content[1] = ft_nullptr;
+    parse_error = ft_set_stats(&npc, content);
+    test_assert_true(parse_error == 1, "ft_set_stats did not report failure when player entry validation failed");
+    test_assert_true(npc.flags.error == 1, "ft_set_stats did not set the NPC error flag when player entry validation failed");
+    if (npc.spells.magic_drain.target)
+    {
+        cma_free(npc.spells.magic_drain.target);
+        npc.spells.magic_drain.target = ft_nullptr;
+    }
+    ft_cleanup_treeNode();
+    return ;
+}
+
 static void test_npc_json_save_writes_lines()
 {
     ensure_tests_output_directory();
@@ -290,6 +311,7 @@ static void test_player_json_save_and_load()
 
 void run_save_load_tests()
 {
+    test_npc_set_stats_player_entry_failure_sets_error();
     test_npc_json_save_writes_lines();
     test_npc_json_load_populates_fields();
     test_player_json_save_and_load();


### PR DESCRIPTION
## Summary
- ensure `ft_create_data_dir` treats a missing data directory as creatable instead of an access error
- update the create-data-folder test to assert the directory exists using the correct predicate result

## Testing
- make tests
- ./automated_tests


------
https://chatgpt.com/codex/tasks/task_e_68debf958f388331a3904828777ed46d