### PR TITLE
Fix target validation for NPCs and add concentration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ TEST_SRC    = tests/automated_tests.cpp \
              tests/calculate_skills_tests.cpp \
              tests/calculate_util_stats_tests.cpp \
              tests/divine_smite_tests.cpp \
+             tests/concentration_tests.cpp \
              spell_utils.cpp \
              readline_check.cpp \
              fclean.cpp \
@@ -291,7 +292,9 @@ TEST_SRC    = tests/automated_tests.cpp \
               init_info.cpp \
               npc_set_stats.cpp \
               npc_set_stats_string.cpp \
-              npc_set_stats_player.cpp \
+             npc_set_stats_player.cpp \
+             fetch_target.cpp \
+             get_character_info.cpp \
              initialize_key_value_pairs.cpp \
              treeNode.cpp \
              treeNode_functions.cpp \

--- a/fetch_target.cpp
+++ b/fetch_target.cpp
@@ -5,18 +5,40 @@
 t_char *ft_validate_and_fetch_target(char *target_name, t_char * info,
         int *error_code)
 {
-    if (!ft_set_stats_check_name(target_name))
+    int        name_status;
+    int        pc_status;
+    t_char    *target_info;
+
+    name_status = ft_set_stats_check_name(target_name);
+    if (name_status != 0)
     {
+        pc_status = ft_check_player_character(target_name);
+        if (pc_status == 0)
+        {
+            *error_code = 0;
+            return (ft_nullptr);
+        }
+        if (pc_status < 0)
+        {
+            *error_code = pc_status;
+            return (ft_nullptr);
+        }
         pf_printf("111-Error: target does not exist\n");
-        *error_code = 1;
+        *error_code = name_status;
         return (ft_nullptr);
     }
-    if (ft_check_player_character(target_name))
+    pc_status = ft_check_player_character(target_name);
+    if (pc_status == 0)
     {
         *error_code = 0;
         return (ft_nullptr);
     }
-    t_char *target_info = ft_get_info(target_name, info->struct_name);
+    if (pc_status < 0)
+    {
+        *error_code = pc_status;
+        return (ft_nullptr);
+    }
+    target_info = ft_get_info(target_name, info->struct_name);
     if (!target_info)
     {
         pf_printf("109-Error: getting info for %s\n", target_name);

--- a/tests/automated_tests.cpp
+++ b/tests/automated_tests.cpp
@@ -19,6 +19,7 @@ int main()
     run_calculate_util_stats_tests();
     run_divine_smite_tests();
     run_spell_utils_tests();
+    run_concentration_tests();
     std::printf("All tests passed.\n");
     return (0);
 }

--- a/tests/concentration_tests.cpp
+++ b/tests/concentration_tests.cpp
@@ -1,0 +1,122 @@
+#include "test_groups.hpp"
+#include "test_support.hpp"
+#include "../dnd_tools.hpp"
+#include "../character.hpp"
+#include "../libft/CPP_class/class_nullptr.hpp"
+#include <filesystem>
+#include <fstream>
+#include <system_error>
+
+static t_char g_stub_target;
+
+static void reset_stub_target()
+{
+    g_stub_target = {};
+    g_stub_target.name = "npc-target";
+    g_stub_target.save_file = const_cast<char *>("data/npc-target");
+    g_stub_target.version_number = 1;
+    return ;
+}
+
+static t_char *load_stub_target(int index, const char **input, t_name *name, int exception)
+{
+    (void)index;
+    (void)input;
+    (void)name;
+    (void)exception;
+    return (&g_stub_target);
+}
+
+static void create_data_entry(const char *path)
+{
+    std::filesystem::create_directories("data");
+    std::ofstream file(path);
+    test_assert_true(file.good(), "Failed to create data entry for test");
+    file.close();
+    return ;
+}
+
+static void remove_data_entries()
+{
+    std::error_code remove_error;
+
+    std::filesystem::remove_all("data", remove_error);
+    return ;
+}
+
+static void test_validate_fetch_allows_npc_target()
+{
+    t_char      info = {};
+    t_name      entry;
+    int         error_code;
+    t_char      *result;
+
+    create_data_entry("data/npc-target");
+    reset_stub_target();
+    entry.name = const_cast<char *>("npc-target");
+    entry.function = &load_stub_target;
+    entry.next = ft_nullptr;
+    info.struct_name = &entry;
+    error_code = -1;
+    result = ft_validate_and_fetch_target(const_cast<char *>("npc-target"), &info, &error_code);
+    test_assert_true(result == &g_stub_target,
+        "ft_validate_and_fetch_target should load NPC information when target exists");
+    test_assert_true(error_code == 0,
+        "ft_validate_and_fetch_target should report success for valid NPC target");
+    remove_data_entries();
+    return ;
+}
+
+static void test_validate_fetch_skips_player_character()
+{
+    t_char      info = {};
+    t_name      entry;
+    int         error_code;
+    t_char      *result;
+
+    create_data_entry("data/pc--guardian");
+    reset_stub_target();
+    entry.name = const_cast<char *>("pc--guardian");
+    entry.function = &load_stub_target;
+    entry.next = ft_nullptr;
+    info.struct_name = &entry;
+    error_code = -1;
+    result = ft_validate_and_fetch_target(const_cast<char *>("pc--guardian"), &info, &error_code);
+    test_assert_true(result == ft_nullptr,
+        "ft_validate_and_fetch_target should not load protected player characters");
+    test_assert_true(error_code == 0,
+        "ft_validate_and_fetch_target should not report an error for protected player characters");
+    remove_data_entries();
+    return ;
+}
+
+static void test_validate_fetch_reports_missing_target()
+{
+    t_char      info = {};
+    t_name      entry;
+    int         error_code;
+    t_char      *result;
+
+    std::filesystem::create_directories("data");
+    reset_stub_target();
+    entry.name = const_cast<char *>("npc-target");
+    entry.function = &load_stub_target;
+    entry.next = ft_nullptr;
+    info.struct_name = &entry;
+    error_code = -1;
+    result = ft_validate_and_fetch_target(const_cast<char *>("unknown"), &info, &error_code);
+    test_assert_true(result == ft_nullptr,
+        "ft_validate_and_fetch_target should fail for missing targets");
+    test_assert_true(error_code == 1,
+        "ft_validate_and_fetch_target should propagate missing target error code");
+    remove_data_entries();
+    return ;
+}
+
+void run_concentration_tests()
+{
+    test_validate_fetch_allows_npc_target();
+    test_validate_fetch_skips_player_character();
+    test_validate_fetch_reports_missing_target();
+    return ;
+}

--- a/tests/test_groups.hpp
+++ b/tests/test_groups.hpp
@@ -17,5 +17,6 @@ void    run_calculate_skills_tests();
 void    run_calculate_util_stats_tests();
 void    run_divine_smite_tests();
 void    run_spell_utils_tests();
+void    run_concentration_tests();
 
 #endif


### PR DESCRIPTION
## Summary
- update `ft_validate_and_fetch_target` to honor error codes from the name and player-character checks so NPC targets load while PCs remain protected
- add new concentration-focused unit tests and wire them into the automated test target

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dec909d2b88331835995e0788031ad