### PR TITLE
Free concentration targets after saving

### DIFF
--- a/remove_concentration.cpp
+++ b/remove_concentration.cpp
@@ -66,6 +66,7 @@ int ft_remove_concentration(t_char * info)
     }
     ft_concentration_remove_buf(info, &targets);
     ft_cast_concentration_save_files(info, &targets, info_save_file);
+    ft_free_memory_cmt(&targets, i);
     info->flags.alreaddy_saved = 0;
     return (SUCCES);
 }


### PR DESCRIPTION
## Summary
- ensure remove_concentration frees target arrays after saving concentration files to avoid leaks

## Testing
- make tests
- ./automated_tests

------
https://chatgpt.com/codex/tasks/task_e_68ded4cb1f688331b67966ab14fa9cca