### PR TITLE
Use libft status macros for multi target concentration

### DIFF
--- a/cast_concentration_multi_target_01.cpp
+++ b/cast_concentration_multi_target_01.cpp
@@ -43,17 +43,17 @@ int    ft_cast_concentration_multi_target_01(t_char * info, t_buff *buff,
     int                error_code;
 
     if (ft_remove_concentration(info))
-        return (FAILURE);
+        return (FT_FAILURE);
     ft_initialize_variables(&target_data);
     if (!ft_check_target_amount(buff->target_amount))
-        return (FAILURE);
+        return (FT_FAILURE);
     while (targets_collected < buff->target_amount)
     {
         target_data.Pchar_name[targets_collected] = ft_read_target_name(targets_collected);
         if (!target_data.Pchar_name[targets_collected])
         {
             ft_free_memory_cmt(&target_data, targets_collected);
-            return (FAILURE);
+            return (FT_FAILURE);
         }
         target_data.target[targets_collected] = ft_validate_and_fetch_target
             (target_data.Pchar_name[targets_collected], info, &error_code);
@@ -74,7 +74,7 @@ int    ft_cast_concentration_multi_target_01(t_char * info, t_buff *buff,
                 if (error >= MAX_ERROR_COUNT)
                 {
                     ft_free_memory_cmt(&target_data, targets_collected);
-                    return (FAILURE);
+                    return (FT_FAILURE);
                 }
                 continue ;
             }
@@ -85,5 +85,5 @@ int    ft_cast_concentration_multi_target_01(t_char * info, t_buff *buff,
     target_data.buff_info = buff;
     ft_cast_concentration_multi_target_02(info, &target_data, input);
     ft_free_memory_cmt(&target_data, buff->target_amount);
-    return (SUCCES);
+    return (FT_SUCCESS);
 }

--- a/cast_concentration_multi_target_02.cpp
+++ b/cast_concentration_multi_target_02.cpp
@@ -54,7 +54,7 @@ static int    ft_apply_concentration(t_target_data *target_data, t_char * info, 
         static_cast<char **>(cma_calloc(static_cast<size_t>(target_data->buff_info->target_amount + 1),
             sizeof(char *)));
     if (!info->concentration.targets)
-        return (FAILURE);
+        return (FT_FAILURE);
     while (index < target_data->buff_info->target_amount)
     {
         if (target_data->target[index])
@@ -63,13 +63,13 @@ static int    ft_apply_concentration(t_target_data *target_data, t_char * info, 
                         target_data->buff_info))
             {
                 ft_cleanup_concentration_targets(info, index - 1);
-                return (FAILURE);
+                return (FT_FAILURE);
             }
             info->concentration.targets[index] = cma_strdup(target_data->Pchar_name[index]);
             if (!info->concentration.targets[index])
             {
                 ft_cleanup_concentration_targets(info, index - 1);
-                return (FAILURE);
+                return (FT_FAILURE);
             }
         }
         index++;
@@ -81,7 +81,7 @@ static int    ft_apply_concentration(t_target_data *target_data, t_char * info, 
     info->concentration.dice_faces_mod = target_data->buff_info->dice_faces_mod;
     info->concentration.dice_amount_mod = target_data->buff_info->dice_amount_mod;
     info->concentration.duration = target_data->buff_info->duration;
-    return (SUCCES);
+    return (FT_SUCCESS);
 }
 
 void    ft_cast_concentration_multi_target_02(t_char * info,

--- a/remove_concentration.cpp
+++ b/remove_concentration.cpp
@@ -27,16 +27,16 @@ static int    ft_remove_concentration_fetch_targets(t_target_data *targets,
     if (error || !targets->target[i])
     {
         ft_free_memory_cmt(targets, i);
-        return (FAILURE);
+        return (FT_FAILURE);
     }
     targets->target_copy[i] = ft_validate_and_fetch_target(info->concentration.targets[i],
             info, &error);
     if (error || !targets->target_copy[i])
     {
         ft_free_memory_cmt(targets, i);
-        return (FAILURE);
+        return (FT_FAILURE);
     }
-    return (SUCCES);
+    return (FT_SUCCESS);
 }
 
 int ft_remove_concentration(t_char * info)
@@ -52,7 +52,7 @@ int ft_remove_concentration(t_char * info)
     while (info->concentration.targets && info->concentration.targets[i])
     {
         if (ft_remove_concentration_fetch_targets(&targets, info, i))
-            return (FAILURE);
+            return (FT_FAILURE);
         i++;
     }
     t_buff buff = INITIALIZE_T_BUFF;
@@ -62,11 +62,11 @@ int ft_remove_concentration(t_char * info)
     if (info_save_file.get_error() || info_save_file.get_fd() == -1)
     {
         ft_free_memory_cmt(&targets, i);
-        return (FAILURE);
+        return (FT_FAILURE);
     }
     ft_concentration_remove_buf(info, &targets);
     ft_cast_concentration_save_files(info, &targets, info_save_file);
     ft_free_memory_cmt(&targets, i);
     info->flags.alreaddy_saved = 0;
-    return (SUCCES);
+    return (FT_SUCCESS);
 }


### PR DESCRIPTION
## Summary
- replace the remaining FAILURE/SUCCES return codes in the multi-target concentration logic with FT_FAILURE/FT_SUCCESS from libft

## Testing
- make
- make test

------
https://chatgpt.com/codex/tasks/task_e_68e2985d7b64833193cfe526b4b0b497