### PR TITLE
Add guard for short player stat content

### DIFF
--- a/npc_set_stats_player.cpp
+++ b/npc_set_stats_player.cpp
@@ -9,6 +9,8 @@ int    ft_set_stat_player(size_t key_len, const char **field, const char *conten
     size_t        content_len;
 
     content_len = ft_strlen(content);
+    if (content_len < key_len)
+        return (-1);
     assert(content_len >= key_len && "Content is shorter than key!");
     *field = cma_strdup(&content[key_len]);
     if (!*field || ft_check_player_entry(*field))


### PR DESCRIPTION
## Summary
- add a runtime guard so `ft_set_stat_player` returns an error when the content is shorter than the key
- ensure callers see untouched fields when save data is malformed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ae7acfc0833193980789f4b20f5c