### PR TITLE
Ensure ft_set_stat_player validates duplicates safely

### DIFF
--- a/npc_set_stats_player.cpp
+++ b/npc_set_stats_player.cpp
@@ -7,13 +7,24 @@
 int    ft_set_stat_player(size_t key_len, const char **field, const char *content)
 {
     size_t        content_len;
+    const char    *previous_value;
+    char          *duplicate;
 
     content_len = ft_strlen(content);
     if (content_len < key_len)
         return (-1);
     assert(content_len >= key_len && "Content is shorter than key!");
-    *field = cma_strdup(&content[key_len]);
-    if (!*field || ft_check_player_entry(*field))
+    previous_value = *field;
+    duplicate = cma_strdup(&content[key_len]);
+    if (!duplicate)
         return (-1);
+    if (ft_check_player_entry(duplicate))
+    {
+        cma_free(duplicate);
+        return (-1);
+    }
+    if (previous_value)
+        cma_free(const_cast<char *>(previous_value));
+    *field = duplicate;
     return (0);
 }


### PR DESCRIPTION
## Summary
- duplicate the candidate player stat entry into a temporary buffer before validation
- preserve the existing field on allocation or validation failure while cleaning up the temporary copy
- free any previous allocation only after successfully validating the new duplicate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2af094ea48331a823482b775cc1fa