### PR TITLE
Fix initiative removal predicate

### DIFF
--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -49,7 +49,7 @@ int ft_initiative_remove(t_char * info)
         if ((ft_strncmp(info->name, temp, ft_strlen_size_t(info->name)) == 0)
                 && (ft_strlen(temp) > ft_strlen(info->name))
                 && (temp[ft_strlen(info->name)] == '=')
-                && (ft_check_value(&temp[ft_strlen(info->name) + 1])))
+                && (ft_check_value(&temp[ft_strlen(info->name) + 1]) == FT_SUCCESS))
         {
             if (DEBUG == 1)
                 pf_printf("found one %s and %c\n", content[index],


### PR DESCRIPTION
## Summary
- ensure initiative removal only matches valid name entries by checking ft_check_value against FT_SUCCESS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2b5eb3454833189f99a1bb154c7e0