### PR TITLE
Handle turn marker when removing initiative entries

### DIFF
--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -56,9 +56,12 @@ int ft_initiative_remove(t_char * info)
                         content[index][ft_strlen(info->name)]);
             index++;
             if (turn_marker)
+            {
                 removed_turn = 1;
-            if (turn_marker)
-                pf_printf_fd(initiative_file, "--turn--");
+                if (content[index])
+                    pf_printf_fd(initiative_file, "--turn--");
+                turn_marker = 0;
+            }
             continue ;
         }
         pf_printf_fd(initiative_file, "%s", content[index]);


### PR DESCRIPTION
## Summary
- ensure initiative removal only re-emits the turn marker when a subsequent entry remains
- reset the turn marker state after handling removals to avoid stale markers in later iterations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2baa1f504833195999adc050ffada