### PR TITLE
Fix initiative request test mode return value

### DIFF
--- a/initiative_request.cpp
+++ b/initiative_request.cpp
@@ -13,7 +13,10 @@ int ft_request_initiative(t_pc *player)
     int initiative;
 
     if (g_dnd_test == true)
-        return (player->initiative = ft_dice_roll(1, 20));
+    {
+        player->initiative = ft_dice_roll(1, 20);
+        return (0);
+    }
     message = cma_strjoin_multiple(3, "Requesting initiative for ",
         player->name, ": ");
     if (message == ft_nullptr)


### PR DESCRIPTION
## Summary
- return success from `ft_request_initiative` while still assigning the randomized initiative roll when running in test mode

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c28ce4b88331bd632a3d16db0911