### PR TITLE
Handle empty initiative list gracefully

### DIFF
--- a/initiative_sort_2.cpp
+++ b/initiative_sort_2.cpp
@@ -4,6 +4,7 @@
 #include "libft/CPP_class/class_nullptr.hpp"
 #include "libft/GetNextLine/get_next_line.hpp"
 #include "libft/CPP_class/class_fd_istream.hpp"
+#include "libft/Errno/errno.hpp"
 #include "dnd_tools.hpp"
 #include "player_character.hpp"
 #include <fcntl.h>
@@ -27,6 +28,11 @@ void ft_initiative_print(void)
     content = ft_read_file_lines(file_stream, 1024);
     if (!content)
     {
+        if (ft_errno == ER_SUCCESS)
+        {
+            pf_printf("\n\nInitiative rolls are:\n");
+            return ;
+        }
         pf_printf("261-Error allocating memory\n");
         return ;
     }


### PR DESCRIPTION
## Summary
- include the errno header to inspect the global ft_errno after reading initiative lines
- treat an empty initiative file as a valid case that only prints the header instead of reporting an allocation error

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2c3ae8ccc833189776ca0c46c566b