### PR TITLE
Handle player cleanup when initiative file open fails

### DIFF
--- a/initiative_all.cpp
+++ b/initiative_all.cpp
@@ -144,7 +144,10 @@ static t_pc *ft_read_pc_file(ft_file &file, char *filename, char *filepath)
     }
     file.open(filepath, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (file.get_error())
+    {
+        ft_free_pc(player);
         return (ft_nullptr);
+    }
     ft_save_pc(player, file);
     return (player);
 }


### PR DESCRIPTION
## Summary
- free the allocated player when ft_read_pc_file cannot reopen the PC file for writing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c8dfb19883319bffbdf8d020e09f