### PR TITLE
Ensure initiative file is created with explicit permissions

### DIFF
--- a/update_intiative_file.cpp
+++ b/update_intiative_file.cpp
@@ -7,6 +7,7 @@
 #include "dnd_tools.hpp"
 #include <fcntl.h>
 #include <unistd.h>
+#include <sys/stat.h>
 #include <cstdlib>
 #include <cerrno>
 #include <cstring>
@@ -230,7 +231,8 @@ void ft_initiative_add(t_char * info)
         validated[i].check_result = error;
         i++;
     }
-    ft_file initiative_file("data/data--initiative", O_WRONLY | O_CREAT | O_TRUNC);
+    ft_file initiative_file("data/data--initiative", O_WRONLY | O_CREAT | O_TRUNC,
+            S_IRUSR | S_IWUSR);
     if (initiative_file == -1)
     {
         if (validated)


### PR DESCRIPTION
## Summary
- include the appropriate header for file permission constants
- instantiate `ft_file` with explicit permissions when creating the initiative file

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2daeab5d483318fab445aec95aad3